### PR TITLE
feat: .NET surface for three-layer codec killbits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -298,3 +298,6 @@ __pycache__/
 tempfile.txt
 benchmarks/Imageflow.Benchmarks/BenchmarkDotNet.Artifacts/
 BenchmarkDotNet.Artifacts
+
+# Coordination marker for concurrent agents (per CLAUDE.md)
+.workongoing

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ## v0.15.1 (draft)
 
+* Surface the new `annotations` field from imageflow's `EncodeResult`
+  on `BuildEncodeResult.Annotations`. Adds `EncodeAnnotations`,
+  `CodecSubstitutionAnnotation`, `SubstitutionReason`, and
+  `CodecPriority` DTOs with snake_case wire parsing. Includes a
+  `CodecSubstitutionAnnotation.Describe()` helper for clean log
+  output. Unknown reason/priority wire values survive round-trip on
+  the `*Raw` fields.
 * Now targets .NET 10 (LTS), .NET 8 (LTS), and .NET Standard 2.0/2.1
 * ARM64 support on Windows, macOS, and Linux
 * Minimum System.Text.Json raised to 8.0.6 (on netstandard2.0/2.1 only; inbox on net8.0+)

--- a/src/Imageflow.AllPlatforms/Imageflow.AllPlatforms.csproj
+++ b/src/Imageflow.AllPlatforms/Imageflow.AllPlatforms.csproj
@@ -36,7 +36,14 @@
       <ProjectReference Include="..\Imageflow\Imageflow.Net.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Imageflow.NativeRuntime.All" Version="2.3.1-rc01"/>
+      <!-- Native runtime range: accept v2.3.1-rc01+ through any v3.x, but not v4+.
+           This is the end-user-facing consumer library; the range lets downstream projects
+           keep resolving 2.3.1-rc01 today while permitting an automatic pickup of v3 once
+           a v3 prerelease ships. Imageflow.Net's C# API compiles against both native
+           generations (new surface like SetPolicy/GetNetSupport lives on the existing
+           imageflow_context_send_json ABI — calls against a v2 native simply return
+           InvalidMessageEndpoint). -->
+      <PackageReference Include="Imageflow.NativeRuntime.All" Version="[2.3.1-rc01, 4.0.0)"/>
     </ItemGroup>
   <ItemGroup>
         <None Include="images\icon.png" Pack="true" PackagePath="" />

--- a/src/Imageflow.AllPlatforms/packages.lock.json
+++ b/src/Imageflow.AllPlatforms/packages.lock.json
@@ -4,7 +4,7 @@
     ".NETStandard,Version=v2.0": {
       "Imageflow.NativeRuntime.All": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "JfHaGqSChFOZcyXH8cUXMF/fm1Bn32BBjgkLY+OSCWpVlL82lrsYr/Ue5Llf74q+tEEIIO7U7Xrw1NbugGKB8w==",
         "dependencies": {
@@ -151,7 +151,7 @@
     ".NETStandard,Version=v2.1": {
       "Imageflow.NativeRuntime.All": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "JfHaGqSChFOZcyXH8cUXMF/fm1Bn32BBjgkLY+OSCWpVlL82lrsYr/Ue5Llf74q+tEEIIO7U7Xrw1NbugGKB8w==",
         "dependencies": {
@@ -243,7 +243,7 @@
     "net10.0": {
       "Imageflow.NativeRuntime.All": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "JfHaGqSChFOZcyXH8cUXMF/fm1Bn32BBjgkLY+OSCWpVlL82lrsYr/Ue5Llf74q+tEEIIO7U7Xrw1NbugGKB8w==",
         "dependencies": {
@@ -312,7 +312,7 @@
     "net8.0": {
       "Imageflow.NativeRuntime.All": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "JfHaGqSChFOZcyXH8cUXMF/fm1Bn32BBjgkLY+OSCWpVlL82lrsYr/Ue5Llf74q+tEEIIO7U7Xrw1NbugGKB8w==",
         "dependencies": {

--- a/src/Imageflow/Bindings/ImageflowCapabilities.cs
+++ b/src/Imageflow/Bindings/ImageflowCapabilities.cs
@@ -1,0 +1,257 @@
+using System.Collections.Concurrent;
+using Imageflow.Fluent;
+
+namespace Imageflow.Bindings;
+
+/// <summary>
+/// Process-wide read-only cache of imageflow's static capability metadata
+/// — MIME types, extensions, codec capabilities, RIAPI key list.
+/// </summary>
+/// <remarks>
+/// Callers that need format/codec info in hot paths (upstream servers
+/// negotiating <c>Accept:</c> headers, IR4 frontends mapping file
+/// extensions to codecs) should route through this class rather than
+/// spinning up a <see cref="JobContext"/> per request.
+///
+/// <para>
+/// <strong>Caching strategy.</strong> Every accessor below is
+/// backed by a <see cref="Lazy{T}"/> or <see cref="ConcurrentDictionary{TKey, TValue}"/>
+/// initialized on first use. Entries are never invalidated — the
+/// underlying data is a property of the native build (compile-time
+/// feature flags, registered codecs) and doesn't change at runtime.
+/// </para>
+///
+/// <para>
+/// Several accessors return <c>null</c> today because the imageflow side
+/// doesn't yet expose a static-info endpoint; see the per-method
+/// <c>TODO</c> notes. When that endpoint lands, the backing lazies will
+/// repoint at it and the public API stays stable.
+/// </para>
+/// </remarks>
+public static class ImageflowCapabilities
+{
+    // --- MIME / extension tables (static; safe to hard-code) -----------
+
+    private static readonly Lazy<IReadOnlyDictionary<ImageFormat, string>> _mimeTypes = new(
+        () => new Dictionary<ImageFormat, string>
+        {
+            { ImageFormat.Jpeg, "image/jpeg" },
+            { ImageFormat.Png,  "image/png"  },
+            { ImageFormat.Gif,  "image/gif"  },
+            { ImageFormat.Webp, "image/webp" },
+            { ImageFormat.Avif, "image/avif" },
+            { ImageFormat.Jxl,  "image/jxl"  },
+            { ImageFormat.Heic, "image/heic" },
+            { ImageFormat.Bmp,  "image/bmp"  },
+            { ImageFormat.Tiff, "image/tiff" },
+            { ImageFormat.Pnm,  "image/x-portable-anymap" },
+        });
+
+    private static readonly Lazy<IReadOnlyDictionary<ImageFormat, IReadOnlyList<string>>> _extensions = new(
+        () => new Dictionary<ImageFormat, IReadOnlyList<string>>
+        {
+            { ImageFormat.Jpeg, new[] { "jpg", "jpeg", "jpe", "jif", "jfif" } },
+            { ImageFormat.Png,  new[] { "png" } },
+            { ImageFormat.Gif,  new[] { "gif" } },
+            { ImageFormat.Webp, new[] { "webp" } },
+            { ImageFormat.Avif, new[] { "avif", "avifs" } },
+            { ImageFormat.Jxl,  new[] { "jxl" } },
+            { ImageFormat.Heic, new[] { "heic", "heif", "hif" } },
+            { ImageFormat.Bmp,  new[] { "bmp" } },
+            { ImageFormat.Tiff, new[] { "tif", "tiff" } },
+            { ImageFormat.Pnm,  new[] { "pnm", "pbm", "pgm", "ppm" } },
+        });
+
+    // --- Magic-byte detection (delegates to the existing helper) -------
+
+    /// <summary>
+    /// MIME type for <paramref name="format"/>. Pure-function cached
+    /// lookup — no native call, safe to invoke in hot paths.
+    /// </summary>
+    public static string GetMimeType(ImageFormat format)
+    {
+        return _mimeTypes.Value.TryGetValue(format, out var mime)
+            ? mime
+            : throw new ArgumentOutOfRangeException(nameof(format), format, "Unknown ImageFormat");
+    }
+
+    /// <summary>
+    /// Canonical lowercase file extensions (without leading dot) for
+    /// <paramref name="format"/>. Cached.
+    /// </summary>
+    public static IReadOnlyList<string> GetExtensions(ImageFormat format)
+    {
+        return _extensions.Value.TryGetValue(format, out var exts)
+            ? exts
+            : throw new ArgumentOutOfRangeException(nameof(format), format, "Unknown ImageFormat");
+    }
+
+    /// <summary>
+    /// Detect the image format from the first few bytes of a file.
+    /// Returns <c>null</c> if the bytes don't match any recognized
+    /// signature. The sniff table is baked in; results are stable for
+    /// the life of the process (no cache miss, no allocation).
+    /// </summary>
+    /// <remarks>
+    /// Only formats listed in <see cref="ImageFormat"/> are detected.
+    /// <c>HEIC</c>, <c>AVIF</c>, and the various MPEG-4-ish variants
+    /// share an <c>ftyp</c> box shape; the brand (<c>avif</c>, <c>heic</c>,
+    /// <c>mif1</c>, etc.) is checked to disambiguate.
+    /// </remarks>
+    public static ImageFormat? DetectFormat(ReadOnlySpan<byte> magicBytes)
+    {
+        if (magicBytes.Length < 3)
+        {
+            return null;
+        }
+
+        // JPEG: FF D8 FF
+        if (magicBytes[0] == 0xFF && magicBytes[1] == 0xD8 && magicBytes[2] == 0xFF)
+        {
+            return ImageFormat.Jpeg;
+        }
+
+        if (magicBytes.Length >= 8)
+        {
+            // PNG: 89 50 4E 47 0D 0A 1A 0A
+            if (magicBytes[0] == 0x89 && magicBytes[1] == 0x50 && magicBytes[2] == 0x4E && magicBytes[3] == 0x47 &&
+                magicBytes[4] == 0x0D && magicBytes[5] == 0x0A && magicBytes[6] == 0x1A && magicBytes[7] == 0x0A)
+            {
+                return ImageFormat.Png;
+            }
+        }
+
+        if (magicBytes.Length >= 6)
+        {
+            // GIF: "GIF87a" / "GIF89a"
+            if (magicBytes[0] == 'G' && magicBytes[1] == 'I' && magicBytes[2] == 'F' &&
+                magicBytes[3] == '8' && (magicBytes[4] == '7' || magicBytes[4] == '9') && magicBytes[5] == 'a')
+            {
+                return ImageFormat.Gif;
+            }
+        }
+
+        // BMP: "BM"
+        if (magicBytes.Length >= 2 && magicBytes[0] == 'B' && magicBytes[1] == 'M')
+        {
+            return ImageFormat.Bmp;
+        }
+
+        // TIFF (little-endian "II*\0" or big-endian "MM\0*")
+        if (magicBytes.Length >= 4)
+        {
+            if ((magicBytes[0] == 'I' && magicBytes[1] == 'I' && magicBytes[2] == 0x2A && magicBytes[3] == 0x00) ||
+                (magicBytes[0] == 'M' && magicBytes[1] == 'M' && magicBytes[2] == 0x00 && magicBytes[3] == 0x2A))
+            {
+                return ImageFormat.Tiff;
+            }
+        }
+
+        // WebP: "RIFF....WEBP"
+        if (magicBytes.Length >= 12 &&
+            magicBytes[0] == 'R' && magicBytes[1] == 'I' && magicBytes[2] == 'F' && magicBytes[3] == 'F' &&
+            magicBytes[8] == 'W' && magicBytes[9] == 'E' && magicBytes[10] == 'B' && magicBytes[11] == 'P')
+        {
+            return ImageFormat.Webp;
+        }
+
+        // JXL: two signatures — naked codestream FF 0A, or ISOBMFF JXL container
+        if (magicBytes.Length >= 2 && magicBytes[0] == 0xFF && magicBytes[1] == 0x0A)
+        {
+            return ImageFormat.Jxl;
+        }
+        if (magicBytes.Length >= 12 &&
+            magicBytes[0] == 0x00 && magicBytes[1] == 0x00 && magicBytes[2] == 0x00 && magicBytes[3] == 0x0C &&
+            magicBytes[4] == 'J' && magicBytes[5] == 'X' && magicBytes[6] == 'L' && magicBytes[7] == 0x20 &&
+            magicBytes[8] == 0x0D && magicBytes[9] == 0x0A && magicBytes[10] == 0x87 && magicBytes[11] == 0x0A)
+        {
+            return ImageFormat.Jxl;
+        }
+
+        // ISOBMFF ftyp brand (AVIF / HEIC). Layout: ... 'ftyp' <4-byte brand>.
+        if (magicBytes.Length >= 12 &&
+            magicBytes[4] == 'f' && magicBytes[5] == 't' && magicBytes[6] == 'y' && magicBytes[7] == 'p')
+        {
+            var brand = $"{(char)magicBytes[8]}{(char)magicBytes[9]}{(char)magicBytes[10]}{(char)magicBytes[11]}";
+            switch (brand)
+            {
+                case "avif":
+                case "avis":
+                    return ImageFormat.Avif;
+                case "heic":
+                case "heix":
+                case "hevc":
+                case "hevx":
+                case "mif1":
+                case "msf1":
+                case "heim":
+                case "heis":
+                case "hevm":
+                case "hevs":
+                    return ImageFormat.Heic;
+            }
+        }
+
+        // PNM: "P1".."P7" followed by whitespace.
+        if (magicBytes.Length >= 3 && magicBytes[0] == 'P' &&
+            magicBytes[1] >= '1' && magicBytes[1] <= '7' &&
+            (magicBytes[2] == ' ' || magicBytes[2] == '\n' || magicBytes[2] == '\r' || magicBytes[2] == '\t'))
+        {
+            return ImageFormat.Pnm;
+        }
+
+        return null;
+    }
+
+    // --- Native-backed caches (stubbed; TODOs for future endpoints) ----
+
+    private static readonly ConcurrentDictionary<NamedEncoderName, EncoderCapabilities?> _encoderCapabilitiesCache = new();
+
+    /// <summary>
+    /// Per-encoder capability record (supported pixel formats, animation
+    /// support, quality ranges, etc.).
+    /// </summary>
+    /// <remarks>
+    /// TODO: wire to a native static-info endpoint once imageflow exposes
+    /// one. Today this always returns <c>null</c>; the cache shape lets
+    /// us add the backing call without changing the signature.
+    /// </remarks>
+    public static EncoderCapabilities? GetEncoderCapabilities(NamedEncoderName encoder)
+    {
+        return _encoderCapabilitiesCache.GetOrAdd(encoder, _ => null);
+    }
+
+    private static readonly Lazy<IReadOnlyList<string>?> _riapiKeys = new(() =>
+    {
+        // TODO: switch to a native-backed call (e.g. list_riapi_keys) once
+        // it's exposed through a read-only, context-less endpoint. Until
+        // then the cache layer exists but returns null so callers can
+        // fall back gracefully.
+        return null;
+    });
+
+    /// <summary>
+    /// List of RIAPI query-string keys the native build supports. Cached
+    /// once per process; <c>null</c> until the static-info endpoint lands.
+    /// </summary>
+    public static IReadOnlyList<string>? GetRiapiKeys() => _riapiKeys.Value;
+}
+
+/// <summary>
+/// Opaque per-encoder capability record. Intentionally unpopulated today
+/// — stub type so <see cref="ImageflowCapabilities.GetEncoderCapabilities"/>
+/// can return structured data once the native endpoint lands.
+/// </summary>
+public sealed class EncoderCapabilities
+{
+    public NamedEncoderName Encoder { get; }
+    public ImageFormat Format { get; }
+    public bool SupportsAnimation { get; }
+
+    internal EncoderCapabilities(NamedEncoderName encoder, ImageFormat format, bool supportsAnimation)
+    {
+        Encoder = encoder;
+        Format = format;
+        SupportsAnimation = supportsAnimation;
+    }
+}

--- a/src/Imageflow/Bindings/ImageflowCapabilities.cs
+++ b/src/Imageflow/Bindings/ImageflowCapabilities.cs
@@ -100,13 +100,13 @@ public static class ImageflowCapabilities
     /// </remarks>
     public static ImageFormat? DetectFormat(ReadOnlySpan<byte> magicBytes)
     {
-        if (magicBytes.Length < 3)
+        if (magicBytes.Length < 2)
         {
             return null;
         }
 
         // JPEG: FF D8 FF
-        if (magicBytes[0] == 0xFF && magicBytes[1] == 0xD8 && magicBytes[2] == 0xFF)
+        if (magicBytes.Length >= 3 && magicBytes[0] == 0xFF && magicBytes[1] == 0xD8 && magicBytes[2] == 0xFF)
         {
             return ImageFormat.Jpeg;
         }

--- a/src/Imageflow/Bindings/ImageflowException.cs
+++ b/src/Imageflow/Bindings/ImageflowException.cs
@@ -85,6 +85,17 @@ public class ImageflowException : Exception
             return new OperationCanceledException(fullMessage);
         }
 
+        // Recognize the killbits structured envelope so callers can catch a
+        // typed exception with the net-support grid attached.
+        if (message != null)
+        {
+            var killbits = KillbitsDeniedException.TryParse(fullMessage);
+            if (killbits != null)
+            {
+                return killbits;
+            }
+        }
+
         return new ImageflowException(fullMessage);
     }
 }

--- a/src/Imageflow/Bindings/ImageflowMethods.cs
+++ b/src/Imageflow/Bindings/ImageflowMethods.cs
@@ -5,4 +5,6 @@ internal static class ImageflowMethods
     internal const string Execute = "v0.1/execute";
     internal const string GetVersionInfo = "v1/get_version_info";
     internal const string GetImageInfo = "v0.1/get_image_info";
+    internal const string SetPolicy = "v1/context/set_policy";
+    internal const string GetNetSupport = "v1/context/get_net_support";
 }

--- a/src/Imageflow/Bindings/JobContext.cs
+++ b/src/Imageflow/Bindings/JobContext.cs
@@ -37,6 +37,23 @@ public sealed class JobContext : CriticalFinalizerObject, IDisposable, IAssertRe
 
     private readonly Dictionary<int, IoKind> _ioSet = new Dictionary<int, IoKind>();
 
+    // Cached net-support grid. Populated lazily and invalidated on
+    // SetPolicy. Reference-assignments are atomic on all supported
+    // frameworks, so a plain field with Interlocked semantics is enough.
+    private NetSupportResponse? _cachedNetSupport;
+
+    // Count of live native calls made for net-support — exposed only for
+    // tests that want to observe cache hit rates. Incremented on every
+    // get_net_support round-trip and on every SetPolicy call.
+    private int _netSupportNativeCalls;
+
+    /// <summary>
+    /// Number of native round-trips made by this context to fetch the
+    /// net-support grid. Tests use this to assert that the cache is
+    /// serving repeat calls locally. Resets with the context's lifetime.
+    /// </summary>
+    internal int NetSupportNativeCallCount => _netSupportNativeCalls;
+
     public JobContext()
     {
         _handle = new JobContextHandle();
@@ -218,6 +235,112 @@ public sealed class JobContext : CriticalFinalizerObject, IDisposable, IAssertRe
         {
             throw new ImageflowAssertionFailed("get_version_info response does not have a success property");
         }
+    }
+
+    /// <summary>
+    /// Install a trusted-context policy (three-layer killbits +
+    /// scalar limits). Subsequent job-level security can only narrow
+    /// these settings, never widen them.
+    /// </summary>
+    /// <param name="policy">Scalar limits plus killbits to apply at the trusted layer. Allow-list and table-with-true forms are accepted here.</param>
+    /// <param name="requireUnlocked">When <c>true</c>, the native side rejects the call if a trusted policy is already set on this context. Defaults to <c>false</c>.</param>
+    /// <remarks>
+    /// Invalidates the cached <see cref="NetSupportResponse"/> on this
+    /// context; the next <see cref="GetNetSupport"/> call refetches.
+    ///
+    /// Requires a native runtime with the
+    /// <c>v1/context/set_policy</c> endpoint (imageflow PR #720 and
+    /// later). Older builds throw
+    /// <see cref="ImageflowException"/> with an
+    /// <c>InvalidMessageEndpoint</c> error.
+    /// </remarks>
+    public SetPolicyResponse SetPolicy(SecurityOptions policy, bool requireUnlocked = false)
+    {
+        Argument.ThrowIfNull(policy);
+        policy.Validate();
+        AssertReady();
+
+        var request = new JsonObject
+        {
+            ["policy"] = policy.ToJsonNode(),
+            ["require_unlocked"] = requireUnlocked,
+        };
+
+        // Invalidate cache before issuing the call so concurrent readers
+        // can't hand out a stale value during the window the native side
+        // is reshaping the grid.
+        Interlocked.Exchange(ref _cachedNetSupport, null);
+        Interlocked.Increment(ref _netSupportNativeCalls);
+
+        var node = InvokeAndParse(ImageflowMethods.SetPolicy, request);
+        var data = RequireSuccessData(node, ImageflowMethods.SetPolicy);
+        var locked = data.AsObject().TryGetPropertyValue("locked", out var lockedVal) && lockedVal != null
+            && lockedVal.GetValue<bool>();
+        var netSupport = NetSupportResponse.ParseSetPolicyResponse(data, locked);
+
+        // Prime the cache with the grid the native side just returned —
+        // it already matches the post-set_policy state.
+        Interlocked.Exchange(ref _cachedNetSupport, netSupport);
+
+        return new SetPolicyResponse(locked, netSupport);
+    }
+
+    /// <summary>
+    /// Fetch (or return the cached) three-layer net-support grid.
+    /// </summary>
+    /// <remarks>
+    /// Results are cached per-context. The cache is invalidated by
+    /// <see cref="SetPolicy"/> and by disposal; callers can therefore hold
+    /// onto the returned <see cref="NetSupportResponse"/> for read-only
+    /// access without re-querying.
+    ///
+    /// Requires a native runtime that exposes
+    /// <c>v1/context/get_net_support</c>.
+    /// </remarks>
+    public NetSupportResponse GetNetSupport()
+    {
+        AssertReady();
+        var cached = Volatile.Read(ref _cachedNetSupport);
+        if (cached != null)
+        {
+            return cached;
+        }
+        // Double-checked locking: if two threads race into the native
+        // call, only one publishes — the second sees the cached value
+        // first and bails.
+        lock (this)
+        {
+            cached = Volatile.Read(ref _cachedNetSupport);
+            if (cached != null)
+            {
+                return cached;
+            }
+
+            Interlocked.Increment(ref _netSupportNativeCalls);
+            var node = InvokeAndParse(ImageflowMethods.GetNetSupport);
+            var data = RequireSuccessData(node, ImageflowMethods.GetNetSupport);
+            var response = NetSupportResponse.ParseGetNetSupportResponse(data);
+            Volatile.Write(ref _cachedNetSupport, response);
+            return response;
+        }
+    }
+
+    private JsonNode RequireSuccessData(JsonNode? node, string method)
+    {
+        if (node == null)
+        {
+            throw new ImageflowAssertionFailed($"{method} response is null");
+        }
+        var obj = node.AsObject() ?? throw new ImageflowAssertionFailed($"{method} response is not an object");
+        if (!obj.TryGetPropertyValue("success", out var successValue) || successValue?.GetValue<bool>() != true)
+        {
+            throw ImageflowException.FromContext(Handle);
+        }
+        if (!obj.TryGetPropertyValue("data", out var dataValue) || dataValue == null)
+        {
+            throw new ImageflowAssertionFailed($"{method} response missing data");
+        }
+        return dataValue;
     }
 
     public IJsonResponse Invoke(string method, ReadOnlySpan<byte> utf8Json)

--- a/src/Imageflow/Bindings/KillbitsDeniedException.cs
+++ b/src/Imageflow/Bindings/KillbitsDeniedException.cs
@@ -1,0 +1,151 @@
+using System.Text.Json.Nodes;
+
+namespace Imageflow.Bindings;
+
+/// <summary>
+/// Reason the native side refused a decode/encode operation under the
+/// three-layer killbits system.
+/// </summary>
+public enum KillbitsDenialKind
+{
+    /// <summary>An explicit named codec was requested but is denied (<c>codec_not_available</c>).</summary>
+    CodecNotAvailable,
+    /// <summary>Decode for this format is denied at one of the layers (<c>decode_not_available</c>).</summary>
+    DecodeNotAvailable,
+    /// <summary>Encode for this format is denied at one of the layers (<c>encode_not_available</c>).</summary>
+    EncodeNotAvailable,
+}
+
+/// <summary>
+/// Raised when imageflow rejects a job because the killbits grid denies
+/// the requested decode/encode/codec.
+/// </summary>
+/// <remarks>
+/// The native layer embeds a structured JSON body in its error message
+/// when this happens:
+///
+/// <code>
+/// { "error": "codec_not_available", "codec": "mozjpeg_encoder",
+///   "format": "jpeg", "reasons": [...], "net_support": { ... } }
+/// </code>
+///
+/// This exception parses that body and exposes the grid through
+/// <see cref="NetSupport"/> so callers can surface actionable diagnostics
+/// without re-querying <c>v1/context/get_net_support</c>.
+///
+/// If the JSON envelope can't be parsed (malformed / future-version shape),
+/// the exception falls back to exposing the raw message in
+/// <see cref="Exception.Message"/>; <see cref="NetSupport"/> will be
+/// <c>null</c> in that case.
+/// </remarks>
+public sealed class KillbitsDeniedException : ImageflowException
+{
+    public KillbitsDenialKind DenialKind { get; }
+    /// <summary>Snake-case codec name for <see cref="KillbitsDenialKind.CodecNotAvailable"/>; otherwise <c>null</c>.</summary>
+    public string? Codec { get; }
+    /// <summary>Snake-case format name (e.g. <c>"avif"</c>).</summary>
+    public string? Format { get; }
+    /// <summary>Machine-readable denial identifiers mirrored from the native grid.</summary>
+    public IReadOnlyList<string> Reasons { get; }
+    /// <summary>Effective net-support grid captured at rejection time, if the envelope was parseable.</summary>
+    public NetSupportResponse? NetSupport { get; }
+
+    internal KillbitsDeniedException(
+        string message,
+        KillbitsDenialKind kind,
+        string? codec,
+        string? format,
+        IReadOnlyList<string> reasons,
+        NetSupportResponse? netSupport)
+        : base(message)
+    {
+        DenialKind = kind;
+        Codec = codec;
+        Format = format;
+        Reasons = reasons;
+        NetSupport = netSupport;
+    }
+
+    /// <summary>
+    /// Inspect a raw error message. Returns <c>null</c> if the message
+    /// isn't a killbits-shaped envelope.
+    /// </summary>
+    internal static KillbitsDeniedException? TryParse(string rawMessage)
+    {
+        if (string.IsNullOrEmpty(rawMessage))
+        {
+            return null;
+        }
+        // The envelope may be prefixed by "imageflow error: " or similar.
+        // Find the first '{' and parse from there.
+        var braceIdx = rawMessage.IndexOf('{');
+        if (braceIdx < 0)
+        {
+            return null;
+        }
+        var slice = rawMessage.AsSpan(braceIdx).ToString();
+        JsonNode? parsed;
+        try
+        {
+            parsed = JsonNode.Parse(slice);
+        }
+        catch
+        {
+            return null;
+        }
+        if (parsed is not JsonObject envelope)
+        {
+            return null;
+        }
+        var errorTag = envelope.TryGetPropertyValue("error", out var e) && e != null
+            ? e.GetValue<string>()
+            : null;
+        KillbitsDenialKind kind = errorTag switch
+        {
+            "codec_not_available" => KillbitsDenialKind.CodecNotAvailable,
+            "decode_not_available" => KillbitsDenialKind.DecodeNotAvailable,
+            "encode_not_available" => KillbitsDenialKind.EncodeNotAvailable,
+            _ => (KillbitsDenialKind)(-1),
+        };
+        if ((int)kind < 0)
+        {
+            return null;
+        }
+
+        var codec = envelope.TryGetPropertyValue("codec", out var c) && c != null ? c.GetValue<string>() : null;
+        var format = envelope.TryGetPropertyValue("format", out var f) && f != null ? f.GetValue<string>() : null;
+        var reasons = new List<string>();
+        if (envelope.TryGetPropertyValue("reasons", out var r) && r is JsonArray arr)
+        {
+            foreach (var item in arr)
+            {
+                if (item != null)
+                {
+                    reasons.Add(item.GetValue<string>());
+                }
+            }
+        }
+
+        NetSupportResponse? grid = null;
+        if (envelope.TryGetPropertyValue("net_support", out var ns) && ns is JsonObject nsObj)
+        {
+            try
+            {
+                // The envelope's net_support embeds only the grid (no
+                // compile_ceiling / trusted_policy_set wrappers), so build
+                // a synthetic response around it.
+                var wrapper = new JsonObject
+                {
+                    ["net_support"] = nsObj.DeepClone(),
+                };
+                grid = NetSupportResponse.ParseGetNetSupportResponse(wrapper);
+            }
+            catch
+            {
+                grid = null;
+            }
+        }
+
+        return new KillbitsDeniedException(rawMessage, kind, codec, format, reasons, grid);
+    }
+}

--- a/src/Imageflow/Bindings/NetSupportResponse.cs
+++ b/src/Imageflow/Bindings/NetSupportResponse.cs
@@ -1,0 +1,293 @@
+using System.Text.Json.Nodes;
+
+namespace Imageflow.Bindings;
+
+/// <summary>
+/// Per-format decode/encode availability in a <see cref="NetSupportResponse"/>.
+/// </summary>
+/// <remarks>
+/// <see cref="DecodeReasons"/> / <see cref="EncodeReasons"/> are
+/// machine-readable identifiers (snake_case) explaining why a cell ended
+/// up denied — e.g. <c>no_available_encoder</c>, <c>denied_by_trusted_policy</c>.
+/// Empty when the cell is allowed.
+/// </remarks>
+public sealed class FormatSupport
+{
+    public bool Decode { get; }
+    public bool Encode { get; }
+    public IReadOnlyList<string> DecodeReasons { get; }
+    public IReadOnlyList<string> EncodeReasons { get; }
+
+    internal FormatSupport(bool decode, bool encode, IReadOnlyList<string> decodeReasons, IReadOnlyList<string> encodeReasons)
+    {
+        Decode = decode;
+        Encode = encode;
+        DecodeReasons = decodeReasons;
+        EncodeReasons = encodeReasons;
+    }
+
+    internal static FormatSupport FromNode(JsonNode node)
+    {
+        var obj = node.AsObject();
+        var decode = TryBool(obj, "decode") ?? false;
+        var encode = TryBool(obj, "encode") ?? false;
+        var decodeReasons = ReadStringArray(obj, "decode_reasons");
+        var encodeReasons = ReadStringArray(obj, "encode_reasons");
+        return new FormatSupport(decode, encode, decodeReasons, encodeReasons);
+    }
+
+    private static bool? TryBool(JsonObject obj, string key)
+    {
+        return obj.TryGetPropertyValue(key, out var v) && v != null ? v.GetValue<bool>() : null;
+    }
+
+    private static IReadOnlyList<string> ReadStringArray(JsonObject obj, string key)
+    {
+        if (!obj.TryGetPropertyValue(key, out var v) || v is not JsonArray arr)
+        {
+            return Array.Empty<string>();
+        }
+        var list = new List<string>(arr.Count);
+        foreach (var item in arr)
+        {
+            if (item != null)
+            {
+                list.Add(item.GetValue<string>());
+            }
+        }
+        return list;
+    }
+}
+
+/// <summary>
+/// Per-codec availability entry.
+/// </summary>
+public sealed class CodecSupportEntry
+{
+    public bool Available { get; }
+    /// <summary>Snake-case format this codec targets (e.g. <c>"jpeg"</c>).</summary>
+    public string Format { get; }
+    /// <summary>Role — <c>"encoder"</c> or <c>"decoder"</c>.</summary>
+    public string Role { get; }
+    public IReadOnlyList<string> Reasons { get; }
+
+    internal CodecSupportEntry(bool available, string format, string role, IReadOnlyList<string> reasons)
+    {
+        Available = available;
+        Format = format;
+        Role = role;
+        Reasons = reasons;
+    }
+
+    internal static CodecSupportEntry FromNode(JsonNode node)
+    {
+        var obj = node.AsObject();
+        var available = obj.TryGetPropertyValue("available", out var a) && a != null ? a.GetValue<bool>() : false;
+        var format = obj.TryGetPropertyValue("format", out var f) && f != null ? f.GetValue<string>() : string.Empty;
+        var role = obj.TryGetPropertyValue("role", out var r) && r != null ? r.GetValue<string>() : string.Empty;
+        var reasons = ReadStringArray(obj, "reasons");
+        return new CodecSupportEntry(available, format, role, reasons);
+    }
+
+    private static IReadOnlyList<string> ReadStringArray(JsonObject obj, string key)
+    {
+        if (!obj.TryGetPropertyValue(key, out var v) || v is not JsonArray arr)
+        {
+            return Array.Empty<string>();
+        }
+        var list = new List<string>(arr.Count);
+        foreach (var item in arr)
+        {
+            if (item != null)
+            {
+                list.Add(item.GetValue<string>());
+            }
+        }
+        return list;
+    }
+}
+
+/// <summary>
+/// Snapshot of formats and codecs whose compile-time, trusted-policy and
+/// job-level gates all allow them. Keys are the snake_case wire names —
+/// unknown values (new formats/codecs added in later imageflow releases)
+/// are kept in string form so forward compatibility isn't lost.
+/// </summary>
+/// <remarks>
+/// Instances are immutable and cheap to hand out to multiple callers. The
+/// <see cref="ImageflowContext"/> caches the last-seen response and
+/// invalidates only on <see cref="ImageflowContext.SetPolicy"/>.
+/// </remarks>
+public sealed class NetSupportResponse
+{
+    /// <summary>Per-format grid keyed by snake_case format name (e.g. <c>"jpeg"</c>).</summary>
+    public IReadOnlyDictionary<string, FormatSupport> Formats { get; }
+
+    /// <summary>Per-codec grid keyed by snake_case codec name (e.g. <c>"mozjpeg_encoder"</c>).</summary>
+    public IReadOnlyDictionary<string, CodecSupportEntry> Codecs { get; }
+
+    /// <summary>
+    /// Formats / features reported under the <c>compile_ceiling</c> key of
+    /// <c>v1/context/get_net_support</c>. <c>null</c> when the response came
+    /// from <c>v1/context/set_policy</c> (which doesn't include it).
+    /// </summary>
+    public CompileCeilingInfo? CompileCeiling { get; }
+
+    /// <summary><c>true</c> if a trusted policy has been set on the owning context.</summary>
+    public bool TrustedPolicySet { get; }
+
+    internal NetSupportResponse(
+        IReadOnlyDictionary<string, FormatSupport> formats,
+        IReadOnlyDictionary<string, CodecSupportEntry> codecs,
+        CompileCeilingInfo? compileCeiling,
+        bool trustedPolicySet)
+    {
+        Formats = formats;
+        Codecs = codecs;
+        CompileCeiling = compileCeiling;
+        TrustedPolicySet = trustedPolicySet;
+    }
+
+    /// <summary>
+    /// Convenience lookup by snake-case format name. Returns <c>null</c> for
+    /// unknown formats; decode/encode callers should treat a missing entry
+    /// the same as a denial.
+    /// </summary>
+    public FormatSupport? GetFormat(string snakeCaseName)
+    {
+        return Formats.TryGetValue(snakeCaseName, out var v) ? v : null;
+    }
+
+    /// <summary>Convenience lookup by snake-case codec name. Returns <c>null</c> for unknown codecs.</summary>
+    public CodecSupportEntry? GetCodec(string snakeCaseName)
+    {
+        return Codecs.TryGetValue(snakeCaseName, out var v) ? v : null;
+    }
+
+    internal static NetSupportResponse ParseSetPolicyResponse(JsonNode responseData, bool locked)
+    {
+        // SetPolicyV1Response: { ok, locked, net_support: { formats, codecs } }
+        var obj = responseData.AsObject();
+        var netSupport = obj.TryGetPropertyValue("net_support", out var ns) && ns != null
+            ? ns
+            : throw new ImageflowAssertionFailed("set_policy response missing net_support");
+        var (formats, codecs) = ParseGrid(netSupport);
+        // After a successful set_policy call, the trusted policy is set.
+        return new NetSupportResponse(formats, codecs, compileCeiling: null, trustedPolicySet: true);
+    }
+
+    internal static NetSupportResponse ParseGetNetSupportResponse(JsonNode responseData)
+    {
+        // GetNetSupportV1Response: { ok, net_support, trusted_policy_set, compile_ceiling }
+        var obj = responseData.AsObject();
+        var netSupport = obj.TryGetPropertyValue("net_support", out var ns) && ns != null
+            ? ns
+            : throw new ImageflowAssertionFailed("get_net_support response missing net_support");
+        var (formats, codecs) = ParseGrid(netSupport);
+
+        var trustedPolicySet = obj.TryGetPropertyValue("trusted_policy_set", out var tp) && tp != null
+            && tp.GetValue<bool>();
+
+        CompileCeilingInfo? compileCeiling = null;
+        if (obj.TryGetPropertyValue("compile_ceiling", out var cc) && cc != null)
+        {
+            compileCeiling = CompileCeilingInfo.FromNode(cc);
+        }
+
+        return new NetSupportResponse(formats, codecs, compileCeiling, trustedPolicySet);
+    }
+
+    private static (IReadOnlyDictionary<string, FormatSupport>, IReadOnlyDictionary<string, CodecSupportEntry>) ParseGrid(JsonNode netSupport)
+    {
+        var obj = netSupport.AsObject();
+        var formatsDict = new Dictionary<string, FormatSupport>(StringComparer.Ordinal);
+        if (obj.TryGetPropertyValue("formats", out var formatsNode) && formatsNode is JsonObject formatsObj)
+        {
+            foreach (var kv in formatsObj)
+            {
+                if (kv.Value != null)
+                {
+                    formatsDict[kv.Key] = FormatSupport.FromNode(kv.Value);
+                }
+            }
+        }
+
+        var codecsDict = new Dictionary<string, CodecSupportEntry>(StringComparer.Ordinal);
+        if (obj.TryGetPropertyValue("codecs", out var codecsNode) && codecsNode is JsonObject codecsObj)
+        {
+            foreach (var kv in codecsObj)
+            {
+                if (kv.Value != null)
+                {
+                    codecsDict[kv.Key] = CodecSupportEntry.FromNode(kv.Value);
+                }
+            }
+        }
+
+        return (formatsDict, codecsDict);
+    }
+}
+
+/// <summary>
+/// Ceiling imposed by the native build (feature gates + compile-time deny
+/// arrays). Returned from <c>v1/context/get_net_support</c>.
+/// </summary>
+public sealed class CompileCeilingInfo
+{
+    public IReadOnlyList<string> DeniedDecode { get; }
+    public IReadOnlyList<string> DeniedEncode { get; }
+    public IReadOnlyList<string> FeaturesMissing { get; }
+
+    internal CompileCeilingInfo(
+        IReadOnlyList<string> deniedDecode,
+        IReadOnlyList<string> deniedEncode,
+        IReadOnlyList<string> featuresMissing)
+    {
+        DeniedDecode = deniedDecode;
+        DeniedEncode = deniedEncode;
+        FeaturesMissing = featuresMissing;
+    }
+
+    internal static CompileCeilingInfo FromNode(JsonNode node)
+    {
+        var obj = node.AsObject();
+        return new CompileCeilingInfo(
+            ReadStringArray(obj, "denied_decode"),
+            ReadStringArray(obj, "denied_encode"),
+            ReadStringArray(obj, "features_missing"));
+    }
+
+    private static IReadOnlyList<string> ReadStringArray(JsonObject obj, string key)
+    {
+        if (!obj.TryGetPropertyValue(key, out var v) || v is not JsonArray arr)
+        {
+            return Array.Empty<string>();
+        }
+        var list = new List<string>(arr.Count);
+        foreach (var item in arr)
+        {
+            if (item != null)
+            {
+                list.Add(item.GetValue<string>());
+            }
+        }
+        return list;
+    }
+}
+
+/// <summary>
+/// Response from <c>v1/context/set_policy</c> — the net-support grid plus
+/// a <c>locked</c> flag.
+/// </summary>
+public sealed class SetPolicyResponse
+{
+    /// <summary><c>true</c> once a trusted policy has been set on the context.</summary>
+    public bool Locked { get; }
+    public NetSupportResponse NetSupport { get; }
+
+    internal SetPolicyResponse(bool locked, NetSupportResponse netSupport)
+    {
+        Locked = locked;
+        NetSupport = netSupport;
+    }
+}

--- a/src/Imageflow/Fluent/BuildEncodeResult.cs
+++ b/src/Imageflow/Fluent/BuildEncodeResult.cs
@@ -31,6 +31,19 @@ public record BuildEncodeResult
     public required IOutputDestination Destination { get; init; }
 
     /// <summary>
+    /// Forward-extensible annotation bag attached to this encode step.
+    /// Populated when the dispatcher substituted the requested codec,
+    /// surfaced a unit warning, or otherwise has non-error information
+    /// about how this particular encode was served. <c>null</c> when the
+    /// native side emitted no <c>annotations</c> object for this
+    /// encode (the field is <c>skip_serializing_if = Option::is_none</c>
+    /// on the wire).
+    ///
+    /// Maps to <c>"annotations"</c> in json.
+    /// </summary>
+    public EncodeAnnotations? Annotations { get; init; }
+
+    /// <summary>
     /// If this Destination is a BytesDestination, returns the ArraySegment - otherwise null
     /// Returns the byte segment for the given output ID (if that output is a BytesDestination)
     /// </summary>

--- a/src/Imageflow/Fluent/BuildJobResult.cs
+++ b/src/Imageflow/Fluent/BuildJobResult.cs
@@ -153,6 +153,14 @@ public class BuildJobResult
                 throw new ImageflowAssertionFailed(requiredMessage);
             }
             var ioId = ioIdValue?.GetValue<int>() ?? throw new ImageflowAssertionFailed(requiredMessage);
+
+            // annotations is optional (skip_serializing_if on native side) — absence deserializes to null.
+            EncodeAnnotations? annotations = null;
+            if (encode.AsObject().TryGetPropertyValue("annotations", out var annotationsNode) && annotationsNode != null)
+            {
+                annotations = EncodeAnnotations.FromJsonNode(annotationsNode);
+            }
+
             encodeResults.Add(new BuildEncodeResult
             {
                 IoId = ioId,
@@ -160,7 +168,8 @@ public class BuildJobResult
                 Height = hValue?.GetValue<int>() ?? throw new ImageflowAssertionFailed(requiredMessage),
                 PreferredExtension = preferredExtensionValue?.GetValue<string>() ?? throw new ImageflowAssertionFailed(requiredMessage),
                 PreferredMimeType = preferredMimeTypeValue?.GetValue<string>() ?? throw new ImageflowAssertionFailed(requiredMessage),
-                Destination = outputs[ioId]
+                Destination = outputs[ioId],
+                Annotations = annotations,
             });
         }
 

--- a/src/Imageflow/Fluent/EncodeAnnotations.cs
+++ b/src/Imageflow/Fluent/EncodeAnnotations.cs
@@ -1,0 +1,363 @@
+using System.Text.Json.Nodes;
+
+namespace Imageflow.Fluent;
+
+/// <summary>
+/// Reason the dispatcher served a specific-codec <c>EncoderPreset</c> via
+/// a different codec than the one the caller named.
+/// </summary>
+/// <remarks>
+/// Mirrors <c>imageflow_types::killbits::SubstitutionReason</c>. Wire form
+/// on the <c>reason</c> field of <see cref="CodecSubstitutionAnnotation"/>
+/// is snake_case — serde's <c>rename_all = "snake_case"</c> stringifies
+/// each variant as its lowercase-underscore name. That is the form
+/// <see cref="TryParse"/> accepts and <see cref="ToSnakeCaseWire"/> emits.
+///
+/// The dotted form returned by <see cref="ToDottedMessage"/> is the
+/// structured error-body form (<c>codec_killbits.deny_encoders</c>)
+/// useful for human-readable log lines.
+///
+/// The native enum is <c>#[non_exhaustive]</c>: future imageflow releases
+/// may add reasons. Unknown snake_case strings round-trip through
+/// <see cref="CodecSubstitutionAnnotation.ReasonRaw"/> rather than this
+/// enum.
+/// </remarks>
+public enum SubstitutionReason
+{
+    /// <summary>The requested codec was denied by trusted/job <c>deny_encoders</c> / <c>deny_decoders</c>.</summary>
+    CodecKillbitsDenyEncoders,
+    /// <summary>The requested codec wasn't in the trusted/job <c>allow_encoders</c> / <c>allow_decoders</c> list.</summary>
+    CodecKillbitsAllowEncodersExcludes,
+    /// <summary>The build didn't compile in the requested codec (feature gate).</summary>
+    CompileFeatureMissing,
+    /// <summary>The build-time <c>COMPILE_DENY_*</c> list denies the format family.</summary>
+    CompileCodecConstDenied,
+    /// <summary>The codec isn't in the runtime <c>enabled_codecs</c> registry.</summary>
+    NotRegistered,
+}
+
+/// <summary>
+/// Build-time codec-priority flavor that selected the substitution
+/// order when the dispatcher re-routed an encode.
+/// </summary>
+/// <remarks>
+/// Mirrors <c>imageflow_types::build_killbits::CodecPriority</c>. Wire
+/// form is snake_case, transported as a free-form string on
+/// <see cref="CodecSubstitutionAnnotation.CodecPriorityRaw"/> so older
+/// or newer native builds can roundtrip unknown values without loss.
+/// Upstream / V3 forks default to <c>v3_zen_first</c>; V2 forks ship
+/// with <c>v2_classic_first</c>.
+/// </remarks>
+public enum CodecPriority
+{
+    /// <summary>V3 default — prefer pure-Rust zen codecs over legacy C backends.</summary>
+    V3ZenFirst,
+    /// <summary>V2 / legacy flavor — prefer the C backends that shipped in V2 forks.</summary>
+    V2ClassicFirst,
+}
+
+internal static class SubstitutionReasonExtensions
+{
+    /// <summary>Wire form used in the <c>reason</c> field (serde <c>rename_all = "snake_case"</c>).</summary>
+    public static string ToSnakeCaseWire(this SubstitutionReason reason) => reason switch
+    {
+        SubstitutionReason.CodecKillbitsDenyEncoders => "codec_killbits_deny_encoders",
+        SubstitutionReason.CodecKillbitsAllowEncodersExcludes => "codec_killbits_allow_encoders_excludes",
+        SubstitutionReason.CompileFeatureMissing => "compile_feature_missing",
+        SubstitutionReason.CompileCodecConstDenied => "compile_codec_const_denied",
+        SubstitutionReason.NotRegistered => "not_registered",
+        _ => throw new ArgumentOutOfRangeException(nameof(reason), reason, "Unknown SubstitutionReason"),
+    };
+
+    /// <summary>
+    /// Dotted form used in structured error payloads and the
+    /// <c>Describe()</c> log helper (e.g. <c>codec_killbits.deny_encoders</c>).
+    /// Mirrors <c>SubstitutionReason::as_snake()</c> on the native side.
+    /// </summary>
+    public static string ToDottedMessage(this SubstitutionReason reason) => reason switch
+    {
+        SubstitutionReason.CodecKillbitsDenyEncoders => "codec_killbits.deny_encoders",
+        SubstitutionReason.CodecKillbitsAllowEncodersExcludes => "codec_killbits.allow_encoders_excludes",
+        SubstitutionReason.CompileFeatureMissing => "compile.feature_missing",
+        SubstitutionReason.CompileCodecConstDenied => "compile.codec_const_denied",
+        SubstitutionReason.NotRegistered => "not_registered",
+        _ => throw new ArgumentOutOfRangeException(nameof(reason), reason, "Unknown SubstitutionReason"),
+    };
+
+    public static bool TryParse(string? wire, out SubstitutionReason reason)
+    {
+        switch (wire)
+        {
+            case "codec_killbits_deny_encoders": reason = SubstitutionReason.CodecKillbitsDenyEncoders; return true;
+            case "codec_killbits_allow_encoders_excludes": reason = SubstitutionReason.CodecKillbitsAllowEncodersExcludes; return true;
+            case "compile_feature_missing": reason = SubstitutionReason.CompileFeatureMissing; return true;
+            case "compile_codec_const_denied": reason = SubstitutionReason.CompileCodecConstDenied; return true;
+            case "not_registered": reason = SubstitutionReason.NotRegistered; return true;
+            default: reason = default; return false;
+        }
+    }
+}
+
+internal static class CodecPriorityExtensions
+{
+    public static string ToSnakeCaseWire(this CodecPriority priority) => priority switch
+    {
+        CodecPriority.V3ZenFirst => "v3_zen_first",
+        CodecPriority.V2ClassicFirst => "v2_classic_first",
+        _ => throw new ArgumentOutOfRangeException(nameof(priority), priority, "Unknown CodecPriority"),
+    };
+
+    public static bool TryParse(string? wire, out CodecPriority priority)
+    {
+        switch (wire)
+        {
+            case "v3_zen_first": priority = CodecPriority.V3ZenFirst; return true;
+            case "v2_classic_first": priority = CodecPriority.V2ClassicFirst; return true;
+            default: priority = default; return false;
+        }
+    }
+}
+
+/// <summary>
+/// Annotation attached to a single encoded image when the dispatcher
+/// routed the caller's specific-codec <c>EncoderPreset</c> to a
+/// different backend that emits the same wire format.
+/// </summary>
+/// <remarks>
+/// Mirrors <c>imageflow_types::killbits::CodecSubstitutionAnnotation</c>.
+/// Surfaces on <see cref="BuildEncodeResult.Annotations"/> via the
+/// <see cref="EncodeAnnotations"/> envelope. A substitution is never an
+/// error — the bytes on <see cref="BuildEncodeResult.Destination"/> are
+/// valid output for the advertised format. The annotation only reports
+/// which backend produced them and why the requested one was skipped.
+///
+/// Unknown wire values for <c>reason</c> and <c>codec_priority</c> are
+/// preserved on <see cref="ReasonRaw"/> / <see cref="CodecPriorityRaw"/>
+/// so forward-compatibility holds when a newer native side introduces
+/// a variant this client doesn't recognize.
+/// </remarks>
+public sealed class CodecSubstitutionAnnotation
+{
+    /// <summary>Wire name of the codec the <c>EncoderPreset</c> named (e.g. <c>mozjpeg_encoder</c>).</summary>
+    public required NamedEncoderName Requested { get; init; }
+
+    /// <summary>Wire name of the codec that actually produced output (e.g. <c>zen_jpeg_encoder</c>).</summary>
+    public required NamedEncoderName Actual { get; init; }
+
+    /// <summary>
+    /// Parsed reason. <c>null</c> when the native side emits a reason
+    /// string this client doesn't recognize — check
+    /// <see cref="ReasonRaw"/> in that case.
+    /// </summary>
+    public required SubstitutionReason? Reason { get; init; }
+
+    /// <summary>Raw wire form of the reason — always populated, preserves unknown values.</summary>
+    public required string ReasonRaw { get; init; }
+
+    /// <summary>
+    /// Parsed codec priority. <c>null</c> when the native side emits a
+    /// priority string this client doesn't recognize — check
+    /// <see cref="CodecPriorityRaw"/> in that case.
+    /// </summary>
+    public required CodecPriority? CodecPriority { get; init; }
+
+    /// <summary>Raw wire form of the codec priority — always populated, preserves unknown values.</summary>
+    public required string CodecPriorityRaw { get; init; }
+
+    /// <summary>
+    /// Human-readable translation notes — one per preset field that was
+    /// remapped onto the substitute codec's configuration
+    /// (e.g. <c>"preset.quality → zen.quality"</c>). Empty list when
+    /// the field was absent or empty on the wire.
+    /// </summary>
+    public required IReadOnlyList<string> FieldTranslations { get; init; }
+
+    /// <summary>
+    /// Field values from the request that were dropped because the
+    /// substitute codec doesn't support them
+    /// (e.g. <c>"preset.zlib_compression"</c> on the lodepng fallback path).
+    /// Empty list when the field was absent or empty on the wire.
+    /// </summary>
+    public required IReadOnlyList<string> DroppedFields { get; init; }
+
+    /// <summary>
+    /// Serializes to the wire form imageflow emits. Mirrors
+    /// <c>serde_json::to_value(CodecSubstitutionAnnotation)</c>:
+    /// enum wire strings, empty <c>field_translations</c> /
+    /// <c>dropped_fields</c> omitted.
+    /// </summary>
+    public JsonNode ToJsonNode()
+    {
+        var obj = new JsonObject
+        {
+            ["requested"] = Requested.ToSnakeCase(),
+            ["actual"] = Actual.ToSnakeCase(),
+            ["reason"] = ReasonRaw,
+            ["codec_priority"] = CodecPriorityRaw,
+        };
+        if (FieldTranslations.Count > 0)
+        {
+            var arr = new JsonArray();
+            foreach (var f in FieldTranslations)
+            {
+                arr.Add((JsonNode?)JsonValue.Create(f));
+            }
+            obj["field_translations"] = arr;
+        }
+        if (DroppedFields.Count > 0)
+        {
+            var arr = new JsonArray();
+            foreach (var f in DroppedFields)
+            {
+                arr.Add((JsonNode?)JsonValue.Create(f));
+            }
+            obj["dropped_fields"] = arr;
+        }
+        return obj;
+    }
+
+    /// <summary>
+    /// Parses a single <c>codec_substitution</c> node. Returns null if
+    /// <paramref name="node"/> is null. Throws
+    /// <see cref="ArgumentException"/> when required fields are
+    /// missing or the encoder names don't parse.
+    /// </summary>
+    public static CodecSubstitutionAnnotation? FromJsonNode(JsonNode? node)
+    {
+        if (node == null)
+        {
+            return null;
+        }
+        var obj = node.AsObject();
+
+        var requestedStr = ReadString(obj, "requested") ?? throw new ArgumentException("codec_substitution.requested missing");
+        var actualStr = ReadString(obj, "actual") ?? throw new ArgumentException("codec_substitution.actual missing");
+        var reasonStr = ReadString(obj, "reason") ?? throw new ArgumentException("codec_substitution.reason missing");
+
+        if (!NamedEncoderExtensions.TryParse(requestedStr, out var requested))
+        {
+            throw new ArgumentException($"codec_substitution.requested '{requestedStr}' is not a recognized named encoder");
+        }
+        if (!NamedEncoderExtensions.TryParse(actualStr, out var actual))
+        {
+            throw new ArgumentException($"codec_substitution.actual '{actualStr}' is not a recognized named encoder");
+        }
+
+        // codec_priority is serde-defaulted on the native side; tolerate absence by falling
+        // back to the V3 default wire value (matches `default_codec_priority_wire()`).
+        var priorityStr = ReadString(obj, "codec_priority") ?? "v3_zen_first";
+
+        var reasonMatched = SubstitutionReasonExtensions.TryParse(reasonStr, out var parsedReason);
+        var priorityMatched = CodecPriorityExtensions.TryParse(priorityStr, out var parsedPriority);
+
+        var fieldTranslations = ReadStringArray(obj, "field_translations");
+        var droppedFields = ReadStringArray(obj, "dropped_fields");
+
+        return new CodecSubstitutionAnnotation
+        {
+            Requested = requested,
+            Actual = actual,
+            Reason = reasonMatched ? parsedReason : null,
+            ReasonRaw = reasonStr,
+            CodecPriority = priorityMatched ? parsedPriority : null,
+            CodecPriorityRaw = priorityStr,
+            FieldTranslations = fieldTranslations,
+            DroppedFields = droppedFields,
+        };
+    }
+
+    /// <summary>
+    /// One-line human-readable description suitable for log output:
+    /// <c>"mozjpeg_encoder → mozjpeg_rs_encoder: codec_killbits.deny_encoders (v3_zen_first)"</c>.
+    /// Uses the dotted reason form and the raw codec-priority wire so
+    /// unknown values are preserved verbatim.
+    /// </summary>
+    public string Describe()
+    {
+        var reasonText = Reason.HasValue ? Reason.Value.ToDottedMessage() : ReasonRaw;
+        return $"{Requested.ToSnakeCase()} \u2192 {Actual.ToSnakeCase()}: {reasonText} ({CodecPriorityRaw})";
+    }
+
+    private static string? ReadString(JsonObject obj, string key)
+    {
+        return obj.TryGetPropertyValue(key, out var v) && v != null ? v.GetValue<string>() : null;
+    }
+
+    private static IReadOnlyList<string> ReadStringArray(JsonObject obj, string key)
+    {
+        if (!obj.TryGetPropertyValue(key, out var v) || v is not JsonArray arr)
+        {
+            return Array.Empty<string>();
+        }
+        var list = new List<string>(arr.Count);
+        foreach (var item in arr)
+        {
+            if (item != null)
+            {
+                list.Add(item.GetValue<string>());
+            }
+        }
+        return list;
+    }
+}
+
+/// <summary>
+/// Forward-extensible annotation envelope attached to one encoded image
+/// in <see cref="BuildEncodeResult.Annotations"/>.
+/// </summary>
+/// <remarks>
+/// Mirrors <c>imageflow_types::killbits::EncodeAnnotations</c>. Each
+/// field is optional; new annotation kinds can be added by the native
+/// side without breaking older clients that ignore them. Callers
+/// should treat unknown fields as safe to ignore.
+/// </remarks>
+public sealed class EncodeAnnotations
+{
+    /// <summary>
+    /// Set iff the dispatcher substituted the requested codec with a
+    /// different one that produces the same wire format.
+    /// </summary>
+    public CodecSubstitutionAnnotation? CodecSubstitution { get; init; }
+
+    /// <summary><c>true</c> iff at least one annotation field is populated.</summary>
+    public bool IsEmpty => CodecSubstitution == null;
+
+    /// <summary>
+    /// Serializes to the wire form imageflow emits: omits
+    /// <c>codec_substitution</c> when null, producing <c>{}</c> for an
+    /// empty envelope.
+    /// </summary>
+    public JsonNode ToJsonNode()
+    {
+        var obj = new JsonObject();
+        if (CodecSubstitution != null)
+        {
+            obj["codec_substitution"] = CodecSubstitution.ToJsonNode();
+        }
+        return obj;
+    }
+
+    /// <summary>
+    /// Parses an <c>annotations</c> node from an encode result.
+    /// Returns null if <paramref name="node"/> is null. An empty
+    /// object parses to a non-null envelope with <see cref="IsEmpty"/>
+    /// <c>== true</c>.
+    /// </summary>
+    public static EncodeAnnotations? FromJsonNode(JsonNode? node)
+    {
+        if (node == null)
+        {
+            return null;
+        }
+        var obj = node.AsObject();
+        CodecSubstitutionAnnotation? substitution = null;
+        if (obj.TryGetPropertyValue("codec_substitution", out var substNode) && substNode != null)
+        {
+            substitution = CodecSubstitutionAnnotation.FromJsonNode(substNode);
+        }
+        return new EncodeAnnotations
+        {
+            CodecSubstitution = substitution,
+        };
+    }
+}

--- a/src/Imageflow/Fluent/FormatKillbits.cs
+++ b/src/Imageflow/Fluent/FormatKillbits.cs
@@ -1,0 +1,230 @@
+using System.Text.Json.Nodes;
+
+namespace Imageflow.Fluent;
+
+/// <summary>
+/// Per-format decode/encode permissions used inside
+/// <see cref="FormatKillbits"/>'s table form.
+/// </summary>
+public readonly struct FormatPermissions(bool decode, bool encode)
+{
+    public bool Decode { get; } = decode;
+    public bool Encode { get; } = encode;
+
+    internal JsonNode ToJsonNode()
+    {
+        return new JsonObject
+        {
+            ["decode"] = Decode,
+            ["encode"] = Encode,
+        };
+    }
+}
+
+/// <summary>
+/// Fine-grained per-format decode/encode gating. One of the three layers
+/// of the killbits system (build-time ceiling ⋂ trusted policy ⋂ job-level
+/// request).
+/// </summary>
+/// <remarks>
+/// Three mutually exclusive request shapes — exactly one group may be set
+/// at a time:
+///
+/// <list type="bullet">
+///   <item><description><see cref="AllowDecode"/> / <see cref="AllowEncode"/> — the listed formats
+///     are the only ones permitted. Anything else is denied. Trusted-policy
+///     layer only; the native side rejects allow-lists submitted at job level.</description></item>
+///   <item><description><see cref="DenyDecode"/> / <see cref="DenyEncode"/> — deny the listed
+///     formats, carry everything else over from the layer above. Safe at
+///     any layer.</description></item>
+///   <item><description><see cref="Formats"/> — explicit
+///     <c>{format → {decode, encode}}</c> table. Trusted-policy layer only
+///     for entries setting <c>true</c>; at job level every entry must be
+///     <c>false</c>.</description></item>
+/// </list>
+///
+/// <see cref="Validate"/> / <see cref="ValidateJobLevel"/> run the same
+/// mutual-exclusion checks the native side performs at deserialize time.
+/// Serialization also rejects mixed forms before crossing the ABI boundary.
+/// </remarks>
+public sealed class FormatKillbits
+{
+    /// <summary>Allow only these formats for decode; everything else is denied. Mutually exclusive with <see cref="DenyDecode"/> and <see cref="Formats"/>.</summary>
+    public IReadOnlyList<ImageFormat>? AllowDecode { get; set; }
+    /// <summary>Deny these formats for decode. Mutually exclusive with <see cref="AllowDecode"/>.</summary>
+    public IReadOnlyList<ImageFormat>? DenyDecode { get; set; }
+    /// <summary>Allow only these formats for encode. Mutually exclusive with <see cref="DenyEncode"/> and <see cref="Formats"/>.</summary>
+    public IReadOnlyList<ImageFormat>? AllowEncode { get; set; }
+    /// <summary>Deny these formats for encode. Mutually exclusive with <see cref="AllowEncode"/>.</summary>
+    public IReadOnlyList<ImageFormat>? DenyEncode { get; set; }
+    /// <summary>Per-format table form. Mutually exclusive with any of the list forms.</summary>
+    public IReadOnlyDictionary<ImageFormat, FormatPermissions>? Formats { get; set; }
+
+    /// <summary>
+    /// Mutual-exclusion validation. Mirrors
+    /// <c>FormatKillbits::validate</c> on the native side.
+    /// </summary>
+    /// <exception cref="ArgumentException">when invariants are violated.</exception>
+    public void Validate()
+    {
+        if (AllowDecode != null && DenyDecode != null)
+        {
+            throw new ArgumentException("pick allow or deny for decode, not both", nameof(AllowDecode));
+        }
+        if (AllowEncode != null && DenyEncode != null)
+        {
+            throw new ArgumentException("pick allow or deny for encode, not both", nameof(AllowEncode));
+        }
+        var hasList = AllowDecode != null || DenyDecode != null || AllowEncode != null || DenyEncode != null;
+        if (hasList && Formats != null)
+        {
+            throw new ArgumentException("pick a single form (allow/deny lists OR formats table)", nameof(Formats));
+        }
+    }
+
+    /// <summary>
+    /// Layer-3 check: no allow-lists, and every table entry must be all
+    /// <c>false</c>. Job-level security may only narrow. Mirrors
+    /// <c>FormatKillbits::validate_job_level</c>.
+    /// </summary>
+    public void ValidateJobLevel()
+    {
+        Validate();
+        if (AllowDecode != null || AllowEncode != null)
+        {
+            throw new ArgumentException(
+                "job-level security may only deny, never allow (layer 3 narrows only)");
+        }
+        if (Formats != null)
+        {
+            foreach (var entry in Formats)
+            {
+                if (entry.Value.Decode || entry.Value.Encode)
+                {
+                    throw new ArgumentException(
+                        "job-level security may only deny, never allow (layer 3 narrows only)");
+                }
+            }
+        }
+    }
+
+    internal JsonNode ToJsonNode()
+    {
+        Validate();
+        var node = new JsonObject();
+        if (AllowDecode != null)
+        {
+            node["allow_decode"] = ToJsonArray(AllowDecode);
+        }
+        if (DenyDecode != null)
+        {
+            node["deny_decode"] = ToJsonArray(DenyDecode);
+        }
+        if (AllowEncode != null)
+        {
+            node["allow_encode"] = ToJsonArray(AllowEncode);
+        }
+        if (DenyEncode != null)
+        {
+            node["deny_encode"] = ToJsonArray(DenyEncode);
+        }
+        if (Formats != null)
+        {
+            var table = new JsonObject();
+            foreach (var kv in Formats)
+            {
+                table[kv.Key.ToSnakeCase()] = kv.Value.ToJsonNode();
+            }
+            node["formats"] = table;
+        }
+        return node;
+    }
+
+    private static JsonArray ToJsonArray(IReadOnlyList<ImageFormat> formats)
+    {
+        var arr = new JsonArray();
+        foreach (var f in formats)
+        {
+            arr.Add((JsonNode?)JsonValue.Create(f.ToSnakeCase()));
+        }
+        return arr;
+    }
+}
+
+/// <summary>
+/// Per-codec decode/encode gating. Complements <see cref="FormatKillbits"/>
+/// by letting operators allow or deny specific named encoder/decoder
+/// backends within a format (e.g. forbid <c>mozjpeg_encoder</c> while keeping
+/// <c>zen_jpeg_encoder</c>).
+/// </summary>
+/// <remarks>
+/// Mutual-exclusion rules:
+///
+/// <list type="bullet">
+///   <item><description><see cref="AllowEncoders"/> is mutually exclusive with <see cref="DenyEncoders"/>.</description></item>
+///   <item><description><see cref="AllowDecoders"/> is mutually exclusive with <see cref="DenyDecoders"/>.</description></item>
+///   <item><description>Job-level security may only set the deny forms.</description></item>
+/// </list>
+/// </remarks>
+public sealed class CodecKillbits
+{
+    public IReadOnlyList<NamedEncoderName>? AllowEncoders { get; set; }
+    public IReadOnlyList<NamedEncoderName>? DenyEncoders { get; set; }
+    public IReadOnlyList<NamedDecoderName>? AllowDecoders { get; set; }
+    public IReadOnlyList<NamedDecoderName>? DenyDecoders { get; set; }
+
+    public void Validate()
+    {
+        if (AllowEncoders != null && DenyEncoders != null)
+        {
+            throw new ArgumentException("pick allow or deny for encoders, not both", nameof(AllowEncoders));
+        }
+        if (AllowDecoders != null && DenyDecoders != null)
+        {
+            throw new ArgumentException("pick allow or deny for decoders, not both", nameof(AllowDecoders));
+        }
+    }
+
+    public void ValidateJobLevel()
+    {
+        Validate();
+        if (AllowEncoders != null || AllowDecoders != null)
+        {
+            throw new ArgumentException(
+                "job-level security may only deny, never allow (layer 3 narrows only)");
+        }
+    }
+
+    internal JsonNode ToJsonNode()
+    {
+        Validate();
+        var node = new JsonObject();
+        if (AllowEncoders != null)
+        {
+            node["allow_encoders"] = ToJsonArray(AllowEncoders, e => e.ToSnakeCase());
+        }
+        if (DenyEncoders != null)
+        {
+            node["deny_encoders"] = ToJsonArray(DenyEncoders, e => e.ToSnakeCase());
+        }
+        if (AllowDecoders != null)
+        {
+            node["allow_decoders"] = ToJsonArray(AllowDecoders, d => d.ToSnakeCase());
+        }
+        if (DenyDecoders != null)
+        {
+            node["deny_decoders"] = ToJsonArray(DenyDecoders, d => d.ToSnakeCase());
+        }
+        return node;
+    }
+
+    private static JsonArray ToJsonArray<T>(IReadOnlyList<T> items, Func<T, string> toSnake)
+    {
+        var arr = new JsonArray();
+        foreach (var item in items)
+        {
+            arr.Add((JsonNode?)JsonValue.Create(toSnake(item)));
+        }
+        return arr;
+    }
+}

--- a/src/Imageflow/Fluent/ImageFormat.cs
+++ b/src/Imageflow/Fluent/ImageFormat.cs
@@ -1,0 +1,85 @@
+namespace Imageflow.Fluent;
+
+/// <summary>
+/// Image formats recognized by the three-layer codec killbits system on the
+/// native imageflow side.
+/// </summary>
+/// <remarks>
+/// Mirrors <c>imageflow_types::killbits::ImageFormat</c>. The serialized
+/// wire form is snake_case (e.g. <c>"jpeg"</c>, <c>"png"</c>).
+///
+/// The native enum is <c>#[non_exhaustive]</c>; new formats may appear in
+/// later imageflow releases. Callers that receive an unknown format string
+/// from <see cref="NetSupportResponse"/> should surface it as opaque text
+/// rather than assuming a closed set.
+/// </remarks>
+public enum ImageFormat
+{
+    Jpeg,
+    Png,
+    Gif,
+    Webp,
+    Avif,
+    Jxl,
+    Heic,
+    Bmp,
+    Tiff,
+    Pnm,
+}
+
+internal static class ImageFormatExtensions
+{
+    public static string ToSnakeCase(this ImageFormat format) => format switch
+    {
+        ImageFormat.Jpeg => "jpeg",
+        ImageFormat.Png => "png",
+        ImageFormat.Gif => "gif",
+        ImageFormat.Webp => "webp",
+        ImageFormat.Avif => "avif",
+        ImageFormat.Jxl => "jxl",
+        ImageFormat.Heic => "heic",
+        ImageFormat.Bmp => "bmp",
+        ImageFormat.Tiff => "tiff",
+        ImageFormat.Pnm => "pnm",
+        _ => throw new ArgumentOutOfRangeException(nameof(format), format, "Unknown ImageFormat"),
+    };
+
+    /// <summary>
+    /// Try to parse a snake_case format string. Returns <c>false</c> for
+    /// values the current binding doesn't recognize (the native enum is
+    /// non-exhaustive — callers that hold the raw string should preserve it
+    /// as-is rather than flattening unknown values to a default).
+    /// </summary>
+    public static bool TryParse(string? snakeCase, out ImageFormat format)
+    {
+        switch (snakeCase)
+        {
+            case "jpeg": format = ImageFormat.Jpeg; return true;
+            case "png": format = ImageFormat.Png; return true;
+            case "gif": format = ImageFormat.Gif; return true;
+            case "webp": format = ImageFormat.Webp; return true;
+            case "avif": format = ImageFormat.Avif; return true;
+            case "jxl": format = ImageFormat.Jxl; return true;
+            case "heic": format = ImageFormat.Heic; return true;
+            case "bmp": format = ImageFormat.Bmp; return true;
+            case "tiff": format = ImageFormat.Tiff; return true;
+            case "pnm": format = ImageFormat.Pnm; return true;
+            default: format = default; return false;
+        }
+    }
+
+    /// <summary>All known formats in stable wire order, matching <c>ImageFormat::ALL</c> on the native side.</summary>
+    public static readonly ImageFormat[] All =
+    [
+        ImageFormat.Jpeg,
+        ImageFormat.Png,
+        ImageFormat.Gif,
+        ImageFormat.Webp,
+        ImageFormat.Avif,
+        ImageFormat.Jxl,
+        ImageFormat.Heic,
+        ImageFormat.Bmp,
+        ImageFormat.Tiff,
+        ImageFormat.Pnm,
+    ];
+}

--- a/src/Imageflow/Fluent/ImageJob.cs
+++ b/src/Imageflow/Fluent/ImageJob.cs
@@ -285,6 +285,9 @@ public class ImageJob : IDisposable
 
     internal JsonObject CreateJsonNodeForFramewiseWithSecurityOptions(SecurityOptions? securityOptions)
     {
+        // Job-level security may only narrow; fail fast on allow-lists or
+        // table-with-true entries before the payload crosses the ABI.
+        securityOptions?.ValidateJobLevel();
         // var message = new
         // {
         //     security = securityOptions?.ToImageflowDynamic(),

--- a/src/Imageflow/Fluent/NamedCodecs.cs
+++ b/src/Imageflow/Fluent/NamedCodecs.cs
@@ -1,0 +1,146 @@
+namespace Imageflow.Fluent;
+
+/// <summary>
+/// Named encoders that can be individually allowed/denied via
+/// <see cref="CodecKillbits"/>.
+/// </summary>
+/// <remarks>
+/// Mirrors <c>imageflow_types::killbits::NamedEncoderName</c>. Wire form is
+/// snake_case (e.g. <c>"mozjpeg_encoder"</c>). The native enum is
+/// <c>#[non_exhaustive]</c>: new backends may be added in later imageflow
+/// releases. Code that receives raw codec names from
+/// <see cref="NetSupportResponse"/> should keep the string form.
+///
+/// Whether an encoder in this enum is actually available at runtime depends
+/// on build-time feature flags on the native side; query
+/// <see cref="ImageflowContext.GetNetSupport"/> for the effective grid.
+/// </remarks>
+public enum NamedEncoderName
+{
+    MozjpegEncoder,
+    ZenJpegEncoder,
+    MozjpegRsEncoder,
+    LibpngEncoder,
+    LodepngEncoder,
+    PngquantEncoder,
+    ZenPngEncoder,
+    WebpEncoder,
+    ZenWebpEncoder,
+    GifEncoder,
+    ZenGifEncoder,
+    ZenAvifEncoder,
+    ZenJxlEncoder,
+    ZenBmpEncoder,
+}
+
+/// <summary>
+/// Named decoders that can be individually allowed/denied via
+/// <see cref="CodecKillbits"/>.
+/// </summary>
+/// <remarks>
+/// Mirrors <c>imageflow_types::killbits::NamedDecoderName</c>. See
+/// <see cref="NamedEncoderName"/> for notes on non-exhaustiveness and
+/// runtime availability.
+/// </remarks>
+public enum NamedDecoderName
+{
+    MozjpegRsDecoder,
+    ImageRsJpegDecoder,
+    ZenJpegDecoder,
+    LibpngDecoder,
+    ImageRsPngDecoder,
+    ZenPngDecoder,
+    GifRsDecoder,
+    ZenGifDecoder,
+    WebpDecoder,
+    ZenWebpDecoder,
+    ZenAvifDecoder,
+    ZenJxlDecoder,
+    ZenBmpDecoder,
+}
+
+internal static class NamedEncoderExtensions
+{
+    public static string ToSnakeCase(this NamedEncoderName codec) => codec switch
+    {
+        NamedEncoderName.MozjpegEncoder => "mozjpeg_encoder",
+        NamedEncoderName.ZenJpegEncoder => "zen_jpeg_encoder",
+        NamedEncoderName.MozjpegRsEncoder => "mozjpeg_rs_encoder",
+        NamedEncoderName.LibpngEncoder => "libpng_encoder",
+        NamedEncoderName.LodepngEncoder => "lodepng_encoder",
+        NamedEncoderName.PngquantEncoder => "pngquant_encoder",
+        NamedEncoderName.ZenPngEncoder => "zen_png_encoder",
+        NamedEncoderName.WebpEncoder => "webp_encoder",
+        NamedEncoderName.ZenWebpEncoder => "zen_webp_encoder",
+        NamedEncoderName.GifEncoder => "gif_encoder",
+        NamedEncoderName.ZenGifEncoder => "zen_gif_encoder",
+        NamedEncoderName.ZenAvifEncoder => "zen_avif_encoder",
+        NamedEncoderName.ZenJxlEncoder => "zen_jxl_encoder",
+        NamedEncoderName.ZenBmpEncoder => "zen_bmp_encoder",
+        _ => throw new ArgumentOutOfRangeException(nameof(codec), codec, "Unknown NamedEncoderName"),
+    };
+
+    public static bool TryParse(string? snakeCase, out NamedEncoderName codec)
+    {
+        switch (snakeCase)
+        {
+            case "mozjpeg_encoder": codec = NamedEncoderName.MozjpegEncoder; return true;
+            case "zen_jpeg_encoder": codec = NamedEncoderName.ZenJpegEncoder; return true;
+            case "mozjpeg_rs_encoder": codec = NamedEncoderName.MozjpegRsEncoder; return true;
+            case "libpng_encoder": codec = NamedEncoderName.LibpngEncoder; return true;
+            case "lodepng_encoder": codec = NamedEncoderName.LodepngEncoder; return true;
+            case "pngquant_encoder": codec = NamedEncoderName.PngquantEncoder; return true;
+            case "zen_png_encoder": codec = NamedEncoderName.ZenPngEncoder; return true;
+            case "webp_encoder": codec = NamedEncoderName.WebpEncoder; return true;
+            case "zen_webp_encoder": codec = NamedEncoderName.ZenWebpEncoder; return true;
+            case "gif_encoder": codec = NamedEncoderName.GifEncoder; return true;
+            case "zen_gif_encoder": codec = NamedEncoderName.ZenGifEncoder; return true;
+            case "zen_avif_encoder": codec = NamedEncoderName.ZenAvifEncoder; return true;
+            case "zen_jxl_encoder": codec = NamedEncoderName.ZenJxlEncoder; return true;
+            case "zen_bmp_encoder": codec = NamedEncoderName.ZenBmpEncoder; return true;
+            default: codec = default; return false;
+        }
+    }
+}
+
+internal static class NamedDecoderExtensions
+{
+    public static string ToSnakeCase(this NamedDecoderName codec) => codec switch
+    {
+        NamedDecoderName.MozjpegRsDecoder => "mozjpeg_rs_decoder",
+        NamedDecoderName.ImageRsJpegDecoder => "image_rs_jpeg_decoder",
+        NamedDecoderName.ZenJpegDecoder => "zen_jpeg_decoder",
+        NamedDecoderName.LibpngDecoder => "libpng_decoder",
+        NamedDecoderName.ImageRsPngDecoder => "image_rs_png_decoder",
+        NamedDecoderName.ZenPngDecoder => "zen_png_decoder",
+        NamedDecoderName.GifRsDecoder => "gif_rs_decoder",
+        NamedDecoderName.ZenGifDecoder => "zen_gif_decoder",
+        NamedDecoderName.WebpDecoder => "webp_decoder",
+        NamedDecoderName.ZenWebpDecoder => "zen_webp_decoder",
+        NamedDecoderName.ZenAvifDecoder => "zen_avif_decoder",
+        NamedDecoderName.ZenJxlDecoder => "zen_jxl_decoder",
+        NamedDecoderName.ZenBmpDecoder => "zen_bmp_decoder",
+        _ => throw new ArgumentOutOfRangeException(nameof(codec), codec, "Unknown NamedDecoderName"),
+    };
+
+    public static bool TryParse(string? snakeCase, out NamedDecoderName codec)
+    {
+        switch (snakeCase)
+        {
+            case "mozjpeg_rs_decoder": codec = NamedDecoderName.MozjpegRsDecoder; return true;
+            case "image_rs_jpeg_decoder": codec = NamedDecoderName.ImageRsJpegDecoder; return true;
+            case "zen_jpeg_decoder": codec = NamedDecoderName.ZenJpegDecoder; return true;
+            case "libpng_decoder": codec = NamedDecoderName.LibpngDecoder; return true;
+            case "image_rs_png_decoder": codec = NamedDecoderName.ImageRsPngDecoder; return true;
+            case "zen_png_decoder": codec = NamedDecoderName.ZenPngDecoder; return true;
+            case "gif_rs_decoder": codec = NamedDecoderName.GifRsDecoder; return true;
+            case "zen_gif_decoder": codec = NamedDecoderName.ZenGifDecoder; return true;
+            case "webp_decoder": codec = NamedDecoderName.WebpDecoder; return true;
+            case "zen_webp_decoder": codec = NamedDecoderName.ZenWebpDecoder; return true;
+            case "zen_avif_decoder": codec = NamedDecoderName.ZenAvifDecoder; return true;
+            case "zen_jxl_decoder": codec = NamedDecoderName.ZenJxlDecoder; return true;
+            case "zen_bmp_decoder": codec = NamedDecoderName.ZenBmpDecoder; return true;
+            default: codec = default; return false;
+        }
+    }
+}

--- a/src/Imageflow/Fluent/SecurityOptions.cs
+++ b/src/Imageflow/Fluent/SecurityOptions.cs
@@ -2,6 +2,24 @@ using System.Text.Json.Nodes;
 
 namespace Imageflow.Fluent;
 
+/// <summary>
+/// Scalar decode/encode resource limits plus the three-layer codec killbits.
+/// </summary>
+/// <remarks>
+/// Mirrors <c>imageflow_types::ExecutionSecurity</c>.
+///
+/// The same class is used for two things:
+///
+/// <list type="bullet">
+///   <item><description>Trusted-context policy, set once via
+///     <see cref="ImageflowContext.SetPolicy"/>. Any allow-list or table-with-<c>true</c>
+///     form is permitted here.</description></item>
+///   <item><description>Per-job security attached through the fluent API (existing
+///     behavior). Only deny-style narrowing is legal at this layer;
+///     <see cref="ValidateJobLevel"/> enforces it before the request
+///     crosses the ABI boundary.</description></item>
+/// </list>
+/// </remarks>
 public class SecurityOptions
 {
 
@@ -10,6 +28,31 @@ public class SecurityOptions
     public FrameSizeLimit? MaxFrameSize { get; set; }
 
     public FrameSizeLimit? MaxEncodeSize { get; set; }
+
+    /// <summary>
+    /// Maximum bytes for a single codec input stream. Default on the
+    /// native side: 256 MiB. <c>null</c> = no change at this layer.
+    /// </summary>
+    public ulong? MaxInputFileBytes { get; set; }
+
+    /// <summary>
+    /// Maximum bytes for a JSON payload before deserialization. Default
+    /// on the native side: 64 MiB. <c>null</c> = no change at this layer.
+    /// </summary>
+    public ulong? MaxJsonBytes { get; set; }
+
+    /// <summary>
+    /// Maximum decoded pixels summed across every frame in a file. Default
+    /// on the native side: 400 megapixels. <c>null</c> = no change at this
+    /// layer.
+    /// </summary>
+    public ulong? MaxTotalFilePixels { get; set; }
+
+    /// <summary>Per-format decode/encode killbits.</summary>
+    public FormatKillbits? Formats { get; set; }
+
+    /// <summary>Per-codec decode/encode killbits.</summary>
+    public CodecKillbits? Codecs { get; set; }
 
     public SecurityOptions SetMaxDecodeSize(FrameSizeLimit? limit)
     {
@@ -25,6 +68,59 @@ public class SecurityOptions
     {
         MaxEncodeSize = limit;
         return this;
+    }
+
+    public SecurityOptions SetMaxInputFileBytes(ulong? bytes)
+    {
+        MaxInputFileBytes = bytes;
+        return this;
+    }
+
+    public SecurityOptions SetMaxJsonBytes(ulong? bytes)
+    {
+        MaxJsonBytes = bytes;
+        return this;
+    }
+
+    public SecurityOptions SetMaxTotalFilePixels(ulong? pixels)
+    {
+        MaxTotalFilePixels = pixels;
+        return this;
+    }
+
+    public SecurityOptions SetFormatKillbits(FormatKillbits? killbits)
+    {
+        Formats = killbits;
+        return this;
+    }
+
+    public SecurityOptions SetCodecKillbits(CodecKillbits? killbits)
+    {
+        Codecs = killbits;
+        return this;
+    }
+
+    /// <summary>
+    /// Run the same mutual-exclusion checks the native side applies at
+    /// <c>v1/context/set_policy</c> deserialize time.
+    /// </summary>
+    public void Validate()
+    {
+        Formats?.Validate();
+        Codecs?.Validate();
+    }
+
+    /// <summary>
+    /// Stricter check for job-level use: no allow-lists anywhere, no
+    /// table-with-true entries. The native side rejects these when found
+    /// under <c>Build001.security</c> / <c>Execute001.security</c>, so
+    /// calling this before sending lets the caller fail fast with a clear
+    /// message instead of a generic deserialization error.
+    /// </summary>
+    public void ValidateJobLevel()
+    {
+        Formats?.ValidateJobLevel();
+        Codecs?.ValidateJobLevel();
     }
 
     [Obsolete("Use ToJsonNode() instead")]
@@ -54,6 +150,31 @@ public class SecurityOptions
         if (MaxEncodeSize != null)
         {
             node.Add("max_encode_size", MaxEncodeSize?.ToJsonNode());
+        }
+
+        if (MaxInputFileBytes != null)
+        {
+            node.Add("max_input_file_bytes", MaxInputFileBytes.Value);
+        }
+
+        if (MaxJsonBytes != null)
+        {
+            node.Add("max_json_bytes", MaxJsonBytes.Value);
+        }
+
+        if (MaxTotalFilePixels != null)
+        {
+            node.Add("max_total_file_pixels", MaxTotalFilePixels.Value);
+        }
+
+        if (Formats != null)
+        {
+            node.Add("formats", Formats.ToJsonNode());
+        }
+
+        if (Codecs != null)
+        {
+            node.Add("codecs", Codecs.ToJsonNode());
         }
 
         return node;

--- a/tests/Imageflow.Test/Imageflow.Test.csproj
+++ b/tests/Imageflow.Test/Imageflow.Test.csproj
@@ -37,13 +37,18 @@
     <NoWarn>$(NoWarn);CA1510</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Imageflow.NativeTool.win-x86" Version="2.3.1-rc01"/>
-    <PackageReference Include="Imageflow.NativeTool.win-x86_64" Version="2.3.1-rc01"/>
-    <PackageReference Include="Imageflow.NativeTool.win-arm64" Version="2.3.1-rc01"/>
-    <PackageReference Include="Imageflow.NativeTool.linux-arm64" Version="2.3.1-rc01"/>
-    <PackageReference Include="Imageflow.NativeTool.linux-x64" Version="2.3.1-rc01"/>
-    <PackageReference Include="Imageflow.NativeTool.osx-x86_64" Version="2.3.1-rc01"/>
-    <PackageReference Include="Imageflow.NativeTool.osx-arm64" Version="2.3.1-rc01"/>
+    <!-- Native runtime range: accept v2.3.1-rc01+ through any v3.x, but not v4+.
+         Prerelease lower bound opts into prerelease resolution (required — no stable 2.x exists).
+         Lowest-applicable rule keeps 2.3.1-rc01 selected today; bump the floor to 3.0.0-alpha.0
+         once a killbits-capable v3 native prerelease lands on NuGet.org to start exercising
+         Category=KillbitsIntegration tests under IMAGEFLOW_HAS_KILLBITS=1. -->
+    <PackageReference Include="Imageflow.NativeTool.win-x86" Version="[2.3.1-rc01, 4.0.0)"/>
+    <PackageReference Include="Imageflow.NativeTool.win-x86_64" Version="[2.3.1-rc01, 4.0.0)"/>
+    <PackageReference Include="Imageflow.NativeTool.win-arm64" Version="[2.3.1-rc01, 4.0.0)"/>
+    <PackageReference Include="Imageflow.NativeTool.linux-arm64" Version="[2.3.1-rc01, 4.0.0)"/>
+    <PackageReference Include="Imageflow.NativeTool.linux-x64" Version="[2.3.1-rc01, 4.0.0)"/>
+    <PackageReference Include="Imageflow.NativeTool.osx-x86_64" Version="[2.3.1-rc01, 4.0.0)"/>
+    <PackageReference Include="Imageflow.NativeTool.osx-arm64" Version="[2.3.1-rc01, 4.0.0)"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.*" />

--- a/tests/Imageflow.Test/TestEncodeAnnotations.cs
+++ b/tests/Imageflow.Test/TestEncodeAnnotations.cs
@@ -1,0 +1,414 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
+using Imageflow.Bindings;
+using Imageflow.Fluent;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Imageflow.Test;
+
+/// <summary>
+/// Round-trip tests for <see cref="EncodeAnnotations"/> and
+/// <see cref="CodecSubstitutionAnnotation"/>. Mirrors the serde
+/// round-trip tests on the native side
+/// (<c>imageflow_types::killbits</c>) so wire compatibility is
+/// validated in both directions.
+/// </summary>
+[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
+public class TestEncodeAnnotations
+{
+    private readonly ITestOutputHelper _output;
+
+    public TestEncodeAnnotations(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    // --- Enum wire forms ---------------------------------------------
+
+    [Theory]
+    [InlineData(SubstitutionReason.CodecKillbitsDenyEncoders, "codec_killbits_deny_encoders")]
+    [InlineData(SubstitutionReason.CodecKillbitsAllowEncodersExcludes, "codec_killbits_allow_encoders_excludes")]
+    [InlineData(SubstitutionReason.CompileFeatureMissing, "compile_feature_missing")]
+    [InlineData(SubstitutionReason.CompileCodecConstDenied, "compile_codec_const_denied")]
+    [InlineData(SubstitutionReason.NotRegistered, "not_registered")]
+    public void SubstitutionReason_SnakeCaseWire_Matches(SubstitutionReason reason, string expected)
+    {
+        Assert.Equal(expected, reason.ToSnakeCaseWire());
+        Assert.True(SubstitutionReasonExtensions.TryParse(expected, out var parsed));
+        Assert.Equal(reason, parsed);
+    }
+
+    [Theory]
+    [InlineData(SubstitutionReason.CodecKillbitsDenyEncoders, "codec_killbits.deny_encoders")]
+    [InlineData(SubstitutionReason.CodecKillbitsAllowEncodersExcludes, "codec_killbits.allow_encoders_excludes")]
+    [InlineData(SubstitutionReason.CompileFeatureMissing, "compile.feature_missing")]
+    [InlineData(SubstitutionReason.CompileCodecConstDenied, "compile.codec_const_denied")]
+    [InlineData(SubstitutionReason.NotRegistered, "not_registered")]
+    public void SubstitutionReason_DottedMessageForm_Matches(SubstitutionReason reason, string expected)
+    {
+        Assert.Equal(expected, reason.ToDottedMessage());
+    }
+
+    [Fact]
+    public void SubstitutionReason_UnknownValue_ReturnsFalse()
+    {
+        Assert.False(SubstitutionReasonExtensions.TryParse("future_reason_xyz", out _));
+        Assert.False(SubstitutionReasonExtensions.TryParse(null, out _));
+    }
+
+    [Theory]
+    [InlineData(CodecPriority.V3ZenFirst, "v3_zen_first")]
+    [InlineData(CodecPriority.V2ClassicFirst, "v2_classic_first")]
+    public void CodecPriority_WireRoundTrips(CodecPriority priority, string expected)
+    {
+        Assert.Equal(expected, priority.ToSnakeCaseWire());
+        Assert.True(CodecPriorityExtensions.TryParse(expected, out var parsed));
+        Assert.Equal(priority, parsed);
+    }
+
+    [Fact]
+    public void CodecPriority_UnknownValue_ReturnsFalse()
+    {
+        Assert.False(CodecPriorityExtensions.TryParse("v4_future", out _));
+    }
+
+    // --- CodecSubstitutionAnnotation round-trip -----------------------
+
+    [Fact]
+    public void CodecSubstitutionAnnotation_FullShape_RoundTrips()
+    {
+        var ann = new CodecSubstitutionAnnotation
+        {
+            Requested = NamedEncoderName.MozjpegEncoder,
+            Actual = NamedEncoderName.ZenJpegEncoder,
+            Reason = SubstitutionReason.CodecKillbitsDenyEncoders,
+            ReasonRaw = "codec_killbits_deny_encoders",
+            CodecPriority = Fluent.CodecPriority.V3ZenFirst,
+            CodecPriorityRaw = "v3_zen_first",
+            FieldTranslations = new[] { "preset.quality \u2192 zen.quality", "preset.progressive \u2192 zen.progressive" },
+            DroppedFields = Array.Empty<string>(),
+        };
+        var json = ann.ToJsonNode().ToJsonString();
+        _output.WriteLine(json);
+        Assert.Contains("\"requested\":\"mozjpeg_encoder\"", json);
+        Assert.Contains("\"actual\":\"zen_jpeg_encoder\"", json);
+        Assert.Contains("\"reason\":\"codec_killbits_deny_encoders\"", json);
+        Assert.Contains("\"codec_priority\":\"v3_zen_first\"", json);
+        Assert.Contains("\"field_translations\":[", json);
+        // dropped_fields empty - omitted per skip_serializing_if=Vec::is_empty
+        Assert.DoesNotContain("dropped_fields", json);
+
+        var parsed = CodecSubstitutionAnnotation.FromJsonNode(JsonNode.Parse(json));
+        Assert.NotNull(parsed);
+        Assert.Equal(NamedEncoderName.MozjpegEncoder, parsed!.Requested);
+        Assert.Equal(NamedEncoderName.ZenJpegEncoder, parsed.Actual);
+        Assert.Equal(SubstitutionReason.CodecKillbitsDenyEncoders, parsed.Reason);
+        Assert.Equal("codec_killbits_deny_encoders", parsed.ReasonRaw);
+        Assert.Equal(Fluent.CodecPriority.V3ZenFirst, parsed.CodecPriority);
+        Assert.Equal("v3_zen_first", parsed.CodecPriorityRaw);
+        Assert.Equal(2, parsed.FieldTranslations.Count);
+        Assert.Empty(parsed.DroppedFields);
+    }
+
+    [Fact]
+    public void CodecSubstitutionAnnotation_DroppedFields_SerializesWhenNonEmpty()
+    {
+        var ann = new CodecSubstitutionAnnotation
+        {
+            Requested = NamedEncoderName.PngquantEncoder,
+            Actual = NamedEncoderName.LodepngEncoder,
+            Reason = SubstitutionReason.CodecKillbitsDenyEncoders,
+            ReasonRaw = "codec_killbits_deny_encoders",
+            CodecPriority = Fluent.CodecPriority.V3ZenFirst,
+            CodecPriorityRaw = "v3_zen_first",
+            FieldTranslations = new[] { "preset.quality \u2192 (dropped)" },
+            DroppedFields = new[] { "preset.quality" },
+        };
+        var json = ann.ToJsonNode().ToJsonString();
+        Assert.Contains("\"dropped_fields\":[\"preset.quality\"]", json);
+
+        var parsed = CodecSubstitutionAnnotation.FromJsonNode(JsonNode.Parse(json));
+        Assert.NotNull(parsed);
+        Assert.Single(parsed!.DroppedFields);
+        Assert.Equal("preset.quality", parsed.DroppedFields[0]);
+    }
+
+    [Fact]
+    public void CodecSubstitutionAnnotation_AbsentCodecPriority_DefaultsToV3ZenFirst()
+    {
+        // Older native payloads lacking codec_priority must still parse;
+        // the native side uses serde default = V3 wire form.
+        var json = @"{
+            ""requested"": ""mozjpeg_encoder"",
+            ""actual"": ""zen_jpeg_encoder"",
+            ""reason"": ""codec_killbits_deny_encoders""
+        }";
+        var parsed = CodecSubstitutionAnnotation.FromJsonNode(JsonNode.Parse(json));
+        Assert.NotNull(parsed);
+        Assert.Equal(Fluent.CodecPriority.V3ZenFirst, parsed!.CodecPriority);
+        Assert.Equal("v3_zen_first", parsed.CodecPriorityRaw);
+        Assert.Empty(parsed.FieldTranslations);
+        Assert.Empty(parsed.DroppedFields);
+    }
+
+    [Fact]
+    public void CodecSubstitutionAnnotation_V2ClassicFirstPriority_Parses()
+    {
+        var json = @"{
+            ""requested"": ""zen_jpeg_encoder"",
+            ""actual"": ""mozjpeg_encoder"",
+            ""reason"": ""not_registered"",
+            ""codec_priority"": ""v2_classic_first""
+        }";
+        var parsed = CodecSubstitutionAnnotation.FromJsonNode(JsonNode.Parse(json));
+        Assert.NotNull(parsed);
+        Assert.Equal(Fluent.CodecPriority.V2ClassicFirst, parsed!.CodecPriority);
+        Assert.Equal("v2_classic_first", parsed.CodecPriorityRaw);
+        Assert.Equal(SubstitutionReason.NotRegistered, parsed.Reason);
+    }
+
+    [Fact]
+    public void CodecSubstitutionAnnotation_UnknownReason_PreservedAsRaw()
+    {
+        // Forward-compat: native side may add new reason variants.
+        var json = @"{
+            ""requested"": ""mozjpeg_encoder"",
+            ""actual"": ""zen_jpeg_encoder"",
+            ""reason"": ""future_reason_xyz"",
+            ""codec_priority"": ""v3_zen_first""
+        }";
+        var parsed = CodecSubstitutionAnnotation.FromJsonNode(JsonNode.Parse(json));
+        Assert.NotNull(parsed);
+        Assert.Null(parsed!.Reason);
+        Assert.Equal("future_reason_xyz", parsed.ReasonRaw);
+        // Describe still works — falls back to raw text.
+        Assert.Contains("future_reason_xyz", parsed.Describe());
+    }
+
+    [Fact]
+    public void CodecSubstitutionAnnotation_UnknownCodecPriority_PreservedAsRaw()
+    {
+        var json = @"{
+            ""requested"": ""mozjpeg_encoder"",
+            ""actual"": ""zen_jpeg_encoder"",
+            ""reason"": ""not_registered"",
+            ""codec_priority"": ""v4_future""
+        }";
+        var parsed = CodecSubstitutionAnnotation.FromJsonNode(JsonNode.Parse(json));
+        Assert.NotNull(parsed);
+        Assert.Null(parsed!.CodecPriority);
+        Assert.Equal("v4_future", parsed.CodecPriorityRaw);
+    }
+
+    [Fact]
+    public void CodecSubstitutionAnnotation_AllSubstitutionReasonVariantsParse()
+    {
+        foreach (SubstitutionReason reason in Enum.GetValues(typeof(SubstitutionReason)))
+        {
+            var wire = reason.ToSnakeCaseWire();
+            var json = $@"{{
+                ""requested"": ""mozjpeg_encoder"",
+                ""actual"": ""zen_jpeg_encoder"",
+                ""reason"": ""{wire}"",
+                ""codec_priority"": ""v3_zen_first""
+            }}";
+            var parsed = CodecSubstitutionAnnotation.FromJsonNode(JsonNode.Parse(json));
+            Assert.NotNull(parsed);
+            Assert.Equal(reason, parsed!.Reason);
+            Assert.Equal(wire, parsed.ReasonRaw);
+        }
+    }
+
+    [Fact]
+    public void CodecSubstitutionAnnotation_MissingRequired_Throws()
+    {
+        var json = @"{""actual"": ""zen_jpeg_encoder"", ""reason"": ""not_registered""}";
+        Assert.Throws<ArgumentException>(() => CodecSubstitutionAnnotation.FromJsonNode(JsonNode.Parse(json)));
+    }
+
+    [Fact]
+    public void CodecSubstitutionAnnotation_UnknownEncoderName_Throws()
+    {
+        var json = @"{
+            ""requested"": ""some_future_encoder"",
+            ""actual"": ""zen_jpeg_encoder"",
+            ""reason"": ""not_registered""
+        }";
+        var ex = Assert.Throws<ArgumentException>(() => CodecSubstitutionAnnotation.FromJsonNode(JsonNode.Parse(json)));
+        Assert.Contains("some_future_encoder", ex.Message);
+    }
+
+    // --- Describe() helper -------------------------------------------
+
+    [Fact]
+    public void Describe_HasStandardFormat()
+    {
+        var ann = new CodecSubstitutionAnnotation
+        {
+            Requested = NamedEncoderName.MozjpegEncoder,
+            Actual = NamedEncoderName.MozjpegRsEncoder,
+            Reason = SubstitutionReason.CodecKillbitsDenyEncoders,
+            ReasonRaw = "codec_killbits_deny_encoders",
+            CodecPriority = Fluent.CodecPriority.V3ZenFirst,
+            CodecPriorityRaw = "v3_zen_first",
+            FieldTranslations = Array.Empty<string>(),
+            DroppedFields = Array.Empty<string>(),
+        };
+        Assert.Equal(
+            "mozjpeg_encoder \u2192 mozjpeg_rs_encoder: codec_killbits.deny_encoders (v3_zen_first)",
+            ann.Describe());
+    }
+
+    // --- EncodeAnnotations envelope ----------------------------------
+
+    [Fact]
+    public void EncodeAnnotations_Empty_SerializesToEmptyObject()
+    {
+        var env = new EncodeAnnotations();
+        Assert.True(env.IsEmpty);
+        Assert.Null(env.CodecSubstitution);
+        Assert.Equal("{}", env.ToJsonNode().ToJsonString());
+    }
+
+    [Fact]
+    public void EncodeAnnotations_ParseEmptyObject_IsEmptyEnvelope()
+    {
+        var env = EncodeAnnotations.FromJsonNode(JsonNode.Parse("{}"));
+        Assert.NotNull(env);
+        Assert.True(env!.IsEmpty);
+        Assert.Null(env.CodecSubstitution);
+    }
+
+    [Fact]
+    public void EncodeAnnotations_ParseNull_ReturnsNull()
+    {
+        Assert.Null(EncodeAnnotations.FromJsonNode(null));
+    }
+
+    [Fact]
+    public void EncodeAnnotations_WithSubstitution_RoundTrips()
+    {
+        var env = new EncodeAnnotations
+        {
+            CodecSubstitution = new CodecSubstitutionAnnotation
+            {
+                Requested = NamedEncoderName.PngquantEncoder,
+                Actual = NamedEncoderName.LodepngEncoder,
+                Reason = SubstitutionReason.CodecKillbitsDenyEncoders,
+                ReasonRaw = "codec_killbits_deny_encoders",
+                CodecPriority = Fluent.CodecPriority.V3ZenFirst,
+                CodecPriorityRaw = "v3_zen_first",
+                FieldTranslations = new[] { "preset.quality \u2192 (dropped)" },
+                DroppedFields = new[] { "preset.quality" },
+            },
+        };
+        Assert.False(env.IsEmpty);
+        var json = env.ToJsonNode().ToJsonString();
+        _output.WriteLine(json);
+        Assert.Contains("\"codec_substitution\"", json);
+
+        var parsed = EncodeAnnotations.FromJsonNode(JsonNode.Parse(json));
+        Assert.NotNull(parsed);
+        Assert.False(parsed!.IsEmpty);
+        Assert.NotNull(parsed.CodecSubstitution);
+        Assert.Equal(NamedEncoderName.PngquantEncoder, parsed.CodecSubstitution!.Requested);
+        Assert.Single(parsed.CodecSubstitution.DroppedFields);
+    }
+
+    // --- Full response round-trip through BuildJobResult.From ---------
+
+    [Fact]
+    public void BuildJobResult_ParsesEncodeResultWithAnnotations()
+    {
+        var payload = JsonNode.Parse(@"{
+            ""success"": true,
+            ""code"": 200,
+            ""data"": {
+                ""job_result"": {
+                    ""encodes"": [
+                        {
+                            ""io_id"": 1,
+                            ""w"": 8,
+                            ""h"": 8,
+                            ""preferred_extension"": ""jpg"",
+                            ""preferred_mime_type"": ""image/jpeg"",
+                            ""annotations"": {
+                                ""codec_substitution"": {
+                                    ""requested"": ""mozjpeg_encoder"",
+                                    ""actual"": ""zen_jpeg_encoder"",
+                                    ""reason"": ""codec_killbits_deny_encoders"",
+                                    ""codec_priority"": ""v3_zen_first"",
+                                    ""field_translations"": [""preset.quality \u2192 zen.quality""]
+                                }
+                            }
+                        }
+                    ],
+                    ""decodes"": []
+                }
+            }
+        }");
+        Assert.NotNull(payload);
+
+        var dest = new BytesDestination();
+        var outputs = new Dictionary<int, IOutputDestination> { { 1, dest } };
+        var response = new FakeJsonResponse(payload!);
+
+        var result = BuildJobResult.From(response, outputs);
+        Assert.Single(result.EncodeResults);
+        var er = result.First!;
+        Assert.Equal(1, er.IoId);
+        Assert.NotNull(er.Annotations);
+        Assert.NotNull(er.Annotations!.CodecSubstitution);
+        Assert.Equal(NamedEncoderName.MozjpegEncoder, er.Annotations.CodecSubstitution!.Requested);
+        Assert.Equal(NamedEncoderName.ZenJpegEncoder, er.Annotations.CodecSubstitution.Actual);
+        Assert.Equal(SubstitutionReason.CodecKillbitsDenyEncoders, er.Annotations.CodecSubstitution.Reason);
+        Assert.Equal(Fluent.CodecPriority.V3ZenFirst, er.Annotations.CodecSubstitution.CodecPriority);
+        Assert.Single(er.Annotations.CodecSubstitution.FieldTranslations);
+    }
+
+    [Fact]
+    public void BuildJobResult_AbsentAnnotations_DeserializesToNull()
+    {
+        // Older native builds don't emit `annotations` at all (or pre-substitution encodes
+        // on any build). Must not break the parse path.
+        var payload = JsonNode.Parse(@"{
+            ""success"": true,
+            ""code"": 200,
+            ""data"": {
+                ""job_result"": {
+                    ""encodes"": [
+                        {
+                            ""io_id"": 1,
+                            ""w"": 8,
+                            ""h"": 8,
+                            ""preferred_extension"": ""jpg"",
+                            ""preferred_mime_type"": ""image/jpeg""
+                        }
+                    ],
+                    ""decodes"": []
+                }
+            }
+        }");
+        Assert.NotNull(payload);
+
+        var dest = new BytesDestination();
+        var outputs = new Dictionary<int, IOutputDestination> { { 1, dest } };
+        var response = new FakeJsonResponse(payload!);
+
+        var result = BuildJobResult.From(response, outputs);
+        var er = result.First!;
+        Assert.Null(er.Annotations);
+    }
+
+    private sealed class FakeJsonResponse : IJsonResponse
+    {
+        private readonly JsonNode _node;
+        public FakeJsonResponse(JsonNode node) { _node = node; }
+        public int ImageflowErrorCode => 200;
+        public string CopyString() => _node.ToJsonString();
+        public JsonNode? Parse() => _node;
+        public byte[] CopyBytes() => System.Text.Encoding.UTF8.GetBytes(_node.ToJsonString());
+        public void Dispose() { }
+    }
+}

--- a/tests/Imageflow.Test/TestKillbits.cs
+++ b/tests/Imageflow.Test/TestKillbits.cs
@@ -1,0 +1,422 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
+using Imageflow.Bindings;
+using Imageflow.Fluent;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Imageflow.Test;
+
+/// <summary>
+/// Unit tests for the three-layer killbits DTOs and client-side cache
+/// behavior. Integration tests (actual native round-trips through
+/// <c>v1/context/set_policy</c> / <c>v1/context/get_net_support</c>) are
+/// in <see cref="TestKillbitsIntegration"/> and are skipped on native
+/// runtimes older than the prerelease that includes imageflow#720.
+/// </summary>
+[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
+public class TestKillbits
+{
+    private readonly ITestOutputHelper _output;
+
+    public TestKillbits(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    // --- DTO round-trip ------------------------------------------------
+
+    [Fact]
+    public void FormatKillbits_DenyList_RoundTrips()
+    {
+        var kb = new FormatKillbits
+        {
+            DenyDecode = new[] { ImageFormat.Avif, ImageFormat.Jxl },
+            DenyEncode = new[] { ImageFormat.Avif },
+        };
+        var json = kb.ToJsonNode().ToJsonString();
+        _output.WriteLine(json);
+        Assert.Contains("\"deny_decode\"", json);
+        Assert.Contains("\"avif\"", json);
+        Assert.Contains("\"jxl\"", json);
+        Assert.Contains("\"deny_encode\"", json);
+        Assert.DoesNotContain("\"allow_", json);
+        Assert.DoesNotContain("\"formats\"", json);
+    }
+
+    [Fact]
+    public void FormatKillbits_TableForm_RoundTrips()
+    {
+        var kb = new FormatKillbits
+        {
+            Formats = new Dictionary<ImageFormat, FormatPermissions>
+            {
+                { ImageFormat.Jpeg, new FormatPermissions(decode: true, encode: false) },
+                { ImageFormat.Avif, new FormatPermissions(decode: false, encode: false) },
+            },
+        };
+        var json = kb.ToJsonNode().ToJsonString();
+        _output.WriteLine(json);
+        Assert.Contains("\"jpeg\"", json);
+        Assert.Contains("\"avif\"", json);
+        Assert.Contains("\"encode\":false", json);
+    }
+
+    [Fact]
+    public void FormatKillbits_MixedListAndTable_Rejected()
+    {
+        var kb = new FormatKillbits
+        {
+            DenyDecode = new[] { ImageFormat.Avif },
+            Formats = new Dictionary<ImageFormat, FormatPermissions>
+            {
+                { ImageFormat.Jpeg, new FormatPermissions(decode: true, encode: false) },
+            },
+        };
+        var ex = Assert.Throws<ArgumentException>(() => kb.Validate());
+        Assert.Contains("single form", ex.Message);
+    }
+
+    [Fact]
+    public void FormatKillbits_AllowAndDenyDecode_Rejected()
+    {
+        var kb = new FormatKillbits
+        {
+            AllowDecode = new[] { ImageFormat.Jpeg },
+            DenyDecode = new[] { ImageFormat.Png },
+        };
+        var ex = Assert.Throws<ArgumentException>(() => kb.Validate());
+        Assert.Contains("decode", ex.Message);
+    }
+
+    [Fact]
+    public void FormatKillbits_AllowAndDenyEncode_Rejected()
+    {
+        var kb = new FormatKillbits
+        {
+            AllowEncode = new[] { ImageFormat.Jpeg },
+            DenyEncode = new[] { ImageFormat.Png },
+        };
+        var ex = Assert.Throws<ArgumentException>(() => kb.Validate());
+        Assert.Contains("encode", ex.Message);
+    }
+
+    [Fact]
+    public void FormatKillbits_JobLevel_RejectsAllowList()
+    {
+        var kb = new FormatKillbits
+        {
+            AllowDecode = new[] { ImageFormat.Jpeg },
+        };
+        var ex = Assert.Throws<ArgumentException>(() => kb.ValidateJobLevel());
+        Assert.Contains("layer 3", ex.Message);
+    }
+
+    [Fact]
+    public void FormatKillbits_JobLevel_RejectsTableTrue()
+    {
+        var kb = new FormatKillbits
+        {
+            Formats = new Dictionary<ImageFormat, FormatPermissions>
+            {
+                { ImageFormat.Jpeg, new FormatPermissions(decode: true, encode: false) },
+            },
+        };
+        var ex = Assert.Throws<ArgumentException>(() => kb.ValidateJobLevel());
+        Assert.Contains("layer 3", ex.Message);
+    }
+
+    [Fact]
+    public void FormatKillbits_JobLevel_AcceptsTableAllFalse()
+    {
+        var kb = new FormatKillbits
+        {
+            Formats = new Dictionary<ImageFormat, FormatPermissions>
+            {
+                { ImageFormat.Jpeg, new FormatPermissions(decode: false, encode: false) },
+            },
+        };
+        kb.ValidateJobLevel();
+    }
+
+    [Fact]
+    public void CodecKillbits_DenyEncoders_RoundTrips()
+    {
+        var kb = new CodecKillbits
+        {
+            DenyEncoders = new[] { NamedEncoderName.MozjpegEncoder },
+            DenyDecoders = new[] { NamedDecoderName.ZenJpegDecoder },
+        };
+        var json = kb.ToJsonNode().ToJsonString();
+        _output.WriteLine(json);
+        Assert.Contains("\"mozjpeg_encoder\"", json);
+        Assert.Contains("\"zen_jpeg_decoder\"", json);
+        Assert.Contains("\"deny_encoders\"", json);
+        Assert.Contains("\"deny_decoders\"", json);
+    }
+
+    [Fact]
+    public void CodecKillbits_AllowAndDenyEncoders_Rejected()
+    {
+        var kb = new CodecKillbits
+        {
+            AllowEncoders = new[] { NamedEncoderName.MozjpegEncoder },
+            DenyEncoders = new[] { NamedEncoderName.ZenJpegEncoder },
+        };
+        Assert.Throws<ArgumentException>(() => kb.Validate());
+    }
+
+    [Fact]
+    public void CodecKillbits_JobLevel_RejectsAllowList()
+    {
+        var kb = new CodecKillbits
+        {
+            AllowEncoders = new[] { NamedEncoderName.MozjpegEncoder },
+        };
+        Assert.Throws<ArgumentException>(() => kb.ValidateJobLevel());
+    }
+
+    [Fact]
+    public void SecurityOptions_SerializesScalarAndKillbits()
+    {
+        var opts = new SecurityOptions
+        {
+            MaxDecodeSize = new FrameSizeLimit(12000, 12000, 100f),
+            MaxInputFileBytes = 10 * 1024 * 1024,
+            MaxJsonBytes = 4 * 1024 * 1024,
+            MaxTotalFilePixels = 400_000_000,
+            Formats = new FormatKillbits { DenyEncode = new[] { ImageFormat.Avif } },
+            Codecs = new CodecKillbits { DenyDecoders = new[] { NamedDecoderName.ZenAvifDecoder } },
+        };
+        var json = opts.ToJsonNode().ToJsonString();
+        _output.WriteLine(json);
+        Assert.Contains("\"max_decode_size\"", json);
+        Assert.Contains("\"max_input_file_bytes\":10485760", json);
+        Assert.Contains("\"max_json_bytes\":4194304", json);
+        Assert.Contains("\"max_total_file_pixels\":400000000", json);
+        Assert.Contains("\"formats\"", json);
+        Assert.Contains("\"codecs\"", json);
+        Assert.Contains("\"avif\"", json);
+        Assert.Contains("\"zen_avif_decoder\"", json);
+    }
+
+    // --- Format/codec name snake_case contract -------------------------
+
+    [Theory]
+    [InlineData(ImageFormat.Jpeg, "jpeg")]
+    [InlineData(ImageFormat.Png, "png")]
+    [InlineData(ImageFormat.Gif, "gif")]
+    [InlineData(ImageFormat.Webp, "webp")]
+    [InlineData(ImageFormat.Avif, "avif")]
+    [InlineData(ImageFormat.Jxl, "jxl")]
+    [InlineData(ImageFormat.Heic, "heic")]
+    [InlineData(ImageFormat.Bmp, "bmp")]
+    [InlineData(ImageFormat.Tiff, "tiff")]
+    [InlineData(ImageFormat.Pnm, "pnm")]
+    public void ImageFormat_ToSnakeCase(ImageFormat f, string expected)
+    {
+        Assert.Equal(expected, f.ToSnakeCase());
+        Assert.True(ImageFormatExtensions.TryParse(expected, out var parsed));
+        Assert.Equal(f, parsed);
+    }
+
+    [Fact]
+    public void NamedEncoderName_ToSnakeCase_AllVariants()
+    {
+        foreach (NamedEncoderName e in Enum.GetValues(typeof(NamedEncoderName)))
+        {
+            var snake = e.ToSnakeCase();
+            Assert.True(NamedEncoderExtensions.TryParse(snake, out var round));
+            Assert.Equal(e, round);
+        }
+    }
+
+    [Fact]
+    public void NamedDecoderName_ToSnakeCase_AllVariants()
+    {
+        foreach (NamedDecoderName d in Enum.GetValues(typeof(NamedDecoderName)))
+        {
+            var snake = d.ToSnakeCase();
+            Assert.True(NamedDecoderExtensions.TryParse(snake, out var round));
+            Assert.Equal(d, round);
+        }
+    }
+
+    // --- Killbits exception parsing -----------------------------------
+
+    [Fact]
+    public void KillbitsDeniedException_Parses_CodecNotAvailable()
+    {
+        const string envelope =
+            "{\"error\": \"codec_not_available\", \"codec\": \"mozjpeg_encoder\", \"format\": \"jpeg\", " +
+            "\"reasons\": [\"denied_by_trusted_policy\"], " +
+            "\"net_support\": {\"formats\":{\"jpeg\":{\"decode\":true,\"encode\":false}}," +
+            "\"codecs\":{\"mozjpeg_encoder\":{\"available\":false,\"format\":\"jpeg\",\"role\":\"encoder\"," +
+            "\"reasons\":[\"denied_by_trusted_policy\"]}}}}";
+        var ex = KillbitsDeniedException.TryParse(envelope);
+        Assert.NotNull(ex);
+        Assert.Equal(KillbitsDenialKind.CodecNotAvailable, ex!.DenialKind);
+        Assert.Equal("mozjpeg_encoder", ex.Codec);
+        Assert.Equal("jpeg", ex.Format);
+        Assert.Contains("denied_by_trusted_policy", ex.Reasons);
+        Assert.NotNull(ex.NetSupport);
+        Assert.True(ex.NetSupport!.Formats.ContainsKey("jpeg"));
+        Assert.False(ex.NetSupport.Codecs["mozjpeg_encoder"].Available);
+    }
+
+    [Fact]
+    public void KillbitsDeniedException_Parses_EncodeNotAvailable()
+    {
+        const string envelope =
+            "{\"error\": \"encode_not_available\", \"format\": \"avif\", " +
+            "\"reasons\": [\"no_available_encoder\"], " +
+            "\"net_support\": {\"formats\":{\"avif\":{\"decode\":false,\"encode\":false}}," +
+            "\"codecs\":{}}}";
+        var ex = KillbitsDeniedException.TryParse(envelope);
+        Assert.NotNull(ex);
+        Assert.Equal(KillbitsDenialKind.EncodeNotAvailable, ex!.DenialKind);
+        Assert.Null(ex.Codec);
+        Assert.Equal("avif", ex.Format);
+    }
+
+    [Fact]
+    public void KillbitsDeniedException_NonKillbitsMessage_ReturnsNull()
+    {
+        Assert.Null(KillbitsDeniedException.TryParse("some unrelated error text"));
+        Assert.Null(KillbitsDeniedException.TryParse(string.Empty));
+        Assert.Null(KillbitsDeniedException.TryParse("{\"error\":\"something_else\"}"));
+    }
+
+    // --- Capability cache ---------------------------------------------
+
+    [Fact]
+    public void ImageflowCapabilities_MimeTypes()
+    {
+        Assert.Equal("image/jpeg", ImageflowCapabilities.GetMimeType(ImageFormat.Jpeg));
+        Assert.Equal("image/avif", ImageflowCapabilities.GetMimeType(ImageFormat.Avif));
+        Assert.Equal("image/jxl", ImageflowCapabilities.GetMimeType(ImageFormat.Jxl));
+    }
+
+    [Fact]
+    public void ImageflowCapabilities_Extensions_JpegIncludesCommonAliases()
+    {
+        var exts = ImageflowCapabilities.GetExtensions(ImageFormat.Jpeg);
+        Assert.Contains("jpg", exts);
+        Assert.Contains("jpeg", exts);
+    }
+
+    [Theory]
+    [InlineData(new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 }, ImageFormat.Jpeg)]
+    [InlineData(new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A }, ImageFormat.Png)]
+    [InlineData(new byte[] { (byte)'G', (byte)'I', (byte)'F', (byte)'8', (byte)'9', (byte)'a' }, ImageFormat.Gif)]
+    [InlineData(new byte[] { (byte)'B', (byte)'M' }, ImageFormat.Bmp)]
+    [InlineData(new byte[] { 0xFF, 0x0A }, ImageFormat.Jxl)]
+    public void ImageflowCapabilities_DetectFormat(byte[] magic, ImageFormat expected)
+    {
+        Assert.Equal(expected, ImageflowCapabilities.DetectFormat(magic));
+    }
+
+    [Fact]
+    public void ImageflowCapabilities_DetectFormat_Webp()
+    {
+        var bytes = new byte[12];
+        bytes[0] = (byte)'R'; bytes[1] = (byte)'I'; bytes[2] = (byte)'F'; bytes[3] = (byte)'F';
+        bytes[8] = (byte)'W'; bytes[9] = (byte)'E'; bytes[10] = (byte)'B'; bytes[11] = (byte)'P';
+        Assert.Equal(ImageFormat.Webp, ImageflowCapabilities.DetectFormat(bytes));
+    }
+
+    [Fact]
+    public void ImageflowCapabilities_DetectFormat_AvifBrand()
+    {
+        var bytes = new byte[] { 0, 0, 0, 0x20, (byte)'f', (byte)'t', (byte)'y', (byte)'p',
+                                 (byte)'a', (byte)'v', (byte)'i', (byte)'f' };
+        Assert.Equal(ImageFormat.Avif, ImageflowCapabilities.DetectFormat(bytes));
+    }
+
+    [Fact]
+    public void ImageflowCapabilities_DetectFormat_HeicBrand()
+    {
+        var bytes = new byte[] { 0, 0, 0, 0x20, (byte)'f', (byte)'t', (byte)'y', (byte)'p',
+                                 (byte)'h', (byte)'e', (byte)'i', (byte)'c' };
+        Assert.Equal(ImageFormat.Heic, ImageflowCapabilities.DetectFormat(bytes));
+    }
+
+    [Fact]
+    public void ImageflowCapabilities_DetectFormat_UnknownReturnsNull()
+    {
+        var bytes = new byte[] { 0x00, 0x01, 0x02, 0x03 };
+        Assert.Null(ImageflowCapabilities.DetectFormat(bytes));
+    }
+
+    [Fact]
+    public void ImageflowCapabilities_GetRiapiKeys_StubReturnsNull()
+    {
+        // TODO: flip expectation once imageflow exposes a static-info
+        // endpoint for the RIAPI key list.
+        Assert.Null(ImageflowCapabilities.GetRiapiKeys());
+    }
+
+    [Fact]
+    public void ImageflowCapabilities_GetEncoderCapabilities_StubReturnsNull()
+    {
+        // TODO: flip expectation once imageflow exposes per-codec capability info.
+        Assert.Null(ImageflowCapabilities.GetEncoderCapabilities(NamedEncoderName.MozjpegEncoder));
+    }
+
+    // --- NetSupport response parsing -----------------------------------
+
+    [Fact]
+    public void NetSupportResponse_ParsesGetNetSupportShape()
+    {
+        var payload = JsonNode.Parse(
+            "{\"ok\":true,\"trusted_policy_set\":true," +
+            "\"net_support\":{" +
+              "\"formats\":{\"jpeg\":{\"decode\":true,\"encode\":true,\"decode_reasons\":[],\"encode_reasons\":[]}," +
+                          "\"avif\":{\"decode\":false,\"encode\":false,\"decode_reasons\":[\"denied_by_trusted_policy\"],\"encode_reasons\":[\"denied_by_trusted_policy\"]}}," +
+              "\"codecs\":{\"mozjpeg_encoder\":{\"available\":true,\"format\":\"jpeg\",\"role\":\"encoder\",\"reasons\":[]}}}," +
+            "\"compile_ceiling\":{\"denied_decode\":[],\"denied_encode\":[],\"features_missing\":[\"heic\"]}}");
+        Assert.NotNull(payload);
+        var parsed = NetSupportResponse.ParseGetNetSupportResponse(payload!);
+        Assert.True(parsed.TrustedPolicySet);
+        Assert.True(parsed.Formats["jpeg"].Decode);
+        Assert.False(parsed.Formats["avif"].Decode);
+        Assert.Contains("denied_by_trusted_policy", parsed.Formats["avif"].DecodeReasons);
+        Assert.True(parsed.Codecs["mozjpeg_encoder"].Available);
+        Assert.Equal("encoder", parsed.Codecs["mozjpeg_encoder"].Role);
+        Assert.NotNull(parsed.CompileCeiling);
+        Assert.Contains("heic", parsed.CompileCeiling!.FeaturesMissing);
+    }
+
+    [Fact]
+    public void NetSupportResponse_GetFormatReturnsNullForUnknown()
+    {
+        var payload = JsonNode.Parse(
+            "{\"net_support\":{\"formats\":{\"jpeg\":{\"decode\":true,\"encode\":true}},\"codecs\":{}}," +
+            "\"trusted_policy_set\":false}");
+        Assert.NotNull(payload);
+        var parsed = NetSupportResponse.ParseGetNetSupportResponse(payload!);
+        Assert.NotNull(parsed.GetFormat("jpeg"));
+        Assert.Null(parsed.GetFormat("nonexistent_format_xyz"));
+    }
+
+    // --- Job-level validation at ImageJob boundary ---------------------
+
+    [Fact]
+    public async Task ImageJob_JobLevelSecurity_RejectsAllowListBeforeAbi()
+    {
+        var imageBytes = Convert.FromBase64String(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX/TQBcNTh/AAAAAXRSTlPM0jRW/QAAAApJREFUeJxjYgAAAAYAAzY3fKgAAAAASUVORK5CYII=");
+        var job = new ImageJob();
+        await Assert.ThrowsAsync<ArgumentException>(async () =>
+        {
+            await job.Decode(new BytesSource(imageBytes))
+                .EncodeToBytes(new GifEncoder())
+                .Finish()
+                .SetSecurityOptions(new SecurityOptions
+                {
+                    Formats = new FormatKillbits { AllowDecode = new[] { ImageFormat.Jpeg } },
+                })
+                .InProcessAsync();
+        });
+    }
+}

--- a/tests/Imageflow.Test/TestKillbitsIntegration.cs
+++ b/tests/Imageflow.Test/TestKillbitsIntegration.cs
@@ -1,0 +1,166 @@
+using System.Diagnostics.CodeAnalysis;
+using Imageflow.Bindings;
+using Imageflow.Fluent;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Imageflow.Test;
+
+/// <summary>
+/// xUnit Fact that only runs when <c>IMAGEFLOW_HAS_KILLBITS=1</c> is set
+/// in the environment. The skip decision is made by the caller (via the
+/// environment variable / CI filter) — never by runtime endpoint sniffing
+/// inside the test body — per repo policy on test skips.
+/// </summary>
+internal sealed class KillbitsFactAttribute : FactAttribute
+{
+    public KillbitsFactAttribute()
+    {
+        if (!string.Equals(Environment.GetEnvironmentVariable("IMAGEFLOW_HAS_KILLBITS"), "1", StringComparison.Ordinal))
+        {
+            Skip = "IMAGEFLOW_HAS_KILLBITS=1 not set; killbits endpoints require an imageflow runtime that includes PR #720";
+        }
+    }
+}
+
+/// <summary>
+/// Integration tests that exercise the real
+/// <c>v1/context/set_policy</c> / <c>v1/context/get_net_support</c>
+/// endpoints on the native runtime.
+/// </summary>
+/// <remarks>
+/// The killbits endpoints landed in imageflow PR #720 and are not in the
+/// 2.3.1-rc01 native runtime pinned by this repo's test csproj. To run
+/// these tests, build against a prerelease native runtime that includes
+/// PR #720 (or swap the project reference to a local Rust workspace
+/// build) and invoke:
+///
+/// <code>IMAGEFLOW_HAS_KILLBITS=1 dotnet test --filter "Category=KillbitsIntegration"</code>
+/// </remarks>
+[SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task")]
+[Trait("Category", "KillbitsIntegration")]
+public class TestKillbitsIntegration
+{
+    private readonly ITestOutputHelper _output;
+
+    public TestKillbitsIntegration(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [KillbitsFact]
+    public void GetNetSupport_CachesResponse()
+    {
+        using var ctx = new JobContext();
+        var initialNative = ctx.NetSupportNativeCallCount;
+        var first = ctx.GetNetSupport();
+        Assert.NotNull(first);
+        var afterFirst = ctx.NetSupportNativeCallCount;
+        Assert.Equal(initialNative + 1, afterFirst);
+
+        var second = ctx.GetNetSupport();
+        // Same instance: cache must hand out the identical reference.
+        Assert.Same(first, second);
+        Assert.Equal(afterFirst, ctx.NetSupportNativeCallCount);
+    }
+
+    [KillbitsFact]
+    public void SetPolicy_InvalidatesCache()
+    {
+        using var ctx = new JobContext();
+        var before = ctx.GetNetSupport();
+        var nativeBeforeSet = ctx.NetSupportNativeCallCount;
+
+        var response = ctx.SetPolicy(new SecurityOptions
+        {
+            Formats = new FormatKillbits { DenyEncode = new[] { ImageFormat.Avif } },
+        });
+        Assert.True(response.Locked);
+        Assert.True(response.NetSupport.TrustedPolicySet);
+
+        // SetPolicy primes the cache with the returned grid — a follow-up
+        // GetNetSupport must not trigger another native round-trip.
+        var nativeCallsAfterSet = ctx.NetSupportNativeCallCount;
+        var after = ctx.GetNetSupport();
+        Assert.NotSame(before, after);
+        Assert.Equal(nativeCallsAfterSet, ctx.NetSupportNativeCallCount);
+
+        // AVIF encode is denied under the new trusted policy.
+        if (after.Formats.TryGetValue("avif", out var avif))
+        {
+            Assert.False(avif.Encode);
+        }
+    }
+
+    [KillbitsFact]
+    public void GetNetSupport_ThreadSafe_OnlyOneNativeCall()
+    {
+        using var ctx = new JobContext();
+        var before = ctx.NetSupportNativeCallCount;
+
+        const int threadCount = 16;
+        var results = new NetSupportResponse?[threadCount];
+        using var start = new ManualResetEventSlim();
+        var threads = new Thread[threadCount];
+        for (var i = 0; i < threadCount; i++)
+        {
+            var idx = i;
+            threads[i] = new Thread(() =>
+            {
+                start.Wait();
+                results[idx] = ctx.GetNetSupport();
+            });
+            threads[i].Start();
+        }
+        start.Set();
+        foreach (var t in threads)
+        {
+            t.Join();
+        }
+
+        // Every thread saw the same cached instance.
+        var first = results[0]!;
+        foreach (var r in results)
+        {
+            Assert.Same(first, r);
+        }
+        // Exactly one native round-trip happened.
+        Assert.Equal(before + 1, ctx.NetSupportNativeCallCount);
+    }
+
+    [KillbitsFact]
+    public async Task DenyAvifEncode_ThrowsStructuredDenial()
+    {
+        // 1x1 PNG.
+        var imageBytes = Convert.FromBase64String(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX/TQBcNTh/AAAAAXRSTlPM0jRW/QAAAApJREFUeJxjYgAAAAYAAzY3fKgAAAAASUVORK5CYII=");
+
+        using var ctx = new JobContext();
+        ctx.SetPolicy(new SecurityOptions
+        {
+            Formats = new FormatKillbits { DenyEncode = new[] { ImageFormat.Webp } },
+        });
+
+        var job = new ImageJob();
+        var ex = await Assert.ThrowsAnyAsync<ImageflowException>(async () =>
+        {
+            await job.Decode(new BytesSource(imageBytes))
+                .EncodeToBytes(new WebPLossyEncoder(80))
+                .Finish()
+                .InProcessAndDisposeAsync();
+        });
+        if (ex is KillbitsDeniedException killbits)
+        {
+            _output.WriteLine($"typed denial: {killbits.DenialKind} codec={killbits.Codec} format={killbits.Format}");
+            Assert.Equal("webp", killbits.Format);
+        }
+        else
+        {
+            // If the native build didn't produce the envelope for this
+            // denial, we still expect the raw message to mention it.
+            _output.WriteLine($"raw denial: {ex.Message}");
+            Assert.Contains("webp", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/tests/Imageflow.Test/packages.lock.json
+++ b/tests/Imageflow.Test/packages.lock.json
@@ -10,43 +10,43 @@
       },
       "Imageflow.NativeTool.linux-arm64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "hnh3ljdvFXaRdf8uGyAp6FEf54g1XavZH5TjEn+zsWTQuMIl2T/CUKF8l+ZYLUdyCwlnupVGPtwJIOdjZVeZ5Q=="
       },
       "Imageflow.NativeTool.linux-x64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "lu/70b2VVCcXgg6nZYIqowGxdtcPw7w+gxW/ZI9tHmYjlOEYFb5deYnxLXc/iIdM2qwFyROG7Fyku4H4+FTMdA=="
       },
       "Imageflow.NativeTool.osx-arm64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "ZVxlfiis1uvcl77QKP6jkCCOnlft/w1M0r5RVvUu5MfTrzzwIp7lErE0FK0QCwHSFVhd2vtsKUQjbhmKWIrOwQ=="
       },
       "Imageflow.NativeTool.osx-x86_64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "Irv4x3GFaVCVkIL6N1NWyu4vukQdSBNoP9ai89UZ5bYAIouhTOSdfD0PxRYu8S0V3FvZAQ9PAZmus54q5BUyzA=="
       },
       "Imageflow.NativeTool.win-arm64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "xLnHwxmpCHo1aPt4aL6iUIfARHN2enBYZcvkyUYfZ66QZeXwSRe7WK1+CsM89FDZmXGV7fsXtu0JW1Y8o8AfNA=="
       },
       "Imageflow.NativeTool.win-x86": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "Cj7lZVcYj5lCvDGSOY6Hb7GQ4v1AAx00Ng1QnDKlmGA6oOxr1umbUJv5B2m+zcgcBTVuK+qtwV+FuGGrUtS0DQ=="
       },
       "Imageflow.NativeTool.win-x86_64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "mYJQf4WBFXY5Cz3B1yMH29JQAhDpQbKH8kmmz3mnafkvTBkxeMNEaceb1rA0HBQyAXiVctBbJ7mXLWe7dBmvWw=="
       },
@@ -221,7 +221,7 @@
       "imageflow.allplatforms": {
         "type": "Project",
         "dependencies": {
-          "Imageflow.NativeRuntime.All": "[2.3.1-rc01, )",
+          "Imageflow.NativeRuntime.All": "[2.3.1-rc01, 4.0.0)",
           "Imageflow.Net": "[0.1.0--notset, )"
         }
       },
@@ -241,43 +241,43 @@
       },
       "Imageflow.NativeTool.linux-arm64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "hnh3ljdvFXaRdf8uGyAp6FEf54g1XavZH5TjEn+zsWTQuMIl2T/CUKF8l+ZYLUdyCwlnupVGPtwJIOdjZVeZ5Q=="
       },
       "Imageflow.NativeTool.linux-x64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "lu/70b2VVCcXgg6nZYIqowGxdtcPw7w+gxW/ZI9tHmYjlOEYFb5deYnxLXc/iIdM2qwFyROG7Fyku4H4+FTMdA=="
       },
       "Imageflow.NativeTool.osx-arm64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "ZVxlfiis1uvcl77QKP6jkCCOnlft/w1M0r5RVvUu5MfTrzzwIp7lErE0FK0QCwHSFVhd2vtsKUQjbhmKWIrOwQ=="
       },
       "Imageflow.NativeTool.osx-x86_64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "Irv4x3GFaVCVkIL6N1NWyu4vukQdSBNoP9ai89UZ5bYAIouhTOSdfD0PxRYu8S0V3FvZAQ9PAZmus54q5BUyzA=="
       },
       "Imageflow.NativeTool.win-arm64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "xLnHwxmpCHo1aPt4aL6iUIfARHN2enBYZcvkyUYfZ66QZeXwSRe7WK1+CsM89FDZmXGV7fsXtu0JW1Y8o8AfNA=="
       },
       "Imageflow.NativeTool.win-x86": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "Cj7lZVcYj5lCvDGSOY6Hb7GQ4v1AAx00Ng1QnDKlmGA6oOxr1umbUJv5B2m+zcgcBTVuK+qtwV+FuGGrUtS0DQ=="
       },
       "Imageflow.NativeTool.win-x86_64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "mYJQf4WBFXY5Cz3B1yMH29JQAhDpQbKH8kmmz3mnafkvTBkxeMNEaceb1rA0HBQyAXiVctBbJ7mXLWe7dBmvWw=="
       },
@@ -452,7 +452,7 @@
       "imageflow.allplatforms": {
         "type": "Project",
         "dependencies": {
-          "Imageflow.NativeRuntime.All": "[2.3.1-rc01, )",
+          "Imageflow.NativeRuntime.All": "[2.3.1-rc01, 4.0.0)",
           "Imageflow.Net": "[0.1.0--notset, )"
         }
       },
@@ -472,43 +472,43 @@
       },
       "Imageflow.NativeTool.linux-arm64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "hnh3ljdvFXaRdf8uGyAp6FEf54g1XavZH5TjEn+zsWTQuMIl2T/CUKF8l+ZYLUdyCwlnupVGPtwJIOdjZVeZ5Q=="
       },
       "Imageflow.NativeTool.linux-x64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "lu/70b2VVCcXgg6nZYIqowGxdtcPw7w+gxW/ZI9tHmYjlOEYFb5deYnxLXc/iIdM2qwFyROG7Fyku4H4+FTMdA=="
       },
       "Imageflow.NativeTool.osx-arm64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "ZVxlfiis1uvcl77QKP6jkCCOnlft/w1M0r5RVvUu5MfTrzzwIp7lErE0FK0QCwHSFVhd2vtsKUQjbhmKWIrOwQ=="
       },
       "Imageflow.NativeTool.osx-x86_64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "Irv4x3GFaVCVkIL6N1NWyu4vukQdSBNoP9ai89UZ5bYAIouhTOSdfD0PxRYu8S0V3FvZAQ9PAZmus54q5BUyzA=="
       },
       "Imageflow.NativeTool.win-arm64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "xLnHwxmpCHo1aPt4aL6iUIfARHN2enBYZcvkyUYfZ66QZeXwSRe7WK1+CsM89FDZmXGV7fsXtu0JW1Y8o8AfNA=="
       },
       "Imageflow.NativeTool.win-x86": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "Cj7lZVcYj5lCvDGSOY6Hb7GQ4v1AAx00Ng1QnDKlmGA6oOxr1umbUJv5B2m+zcgcBTVuK+qtwV+FuGGrUtS0DQ=="
       },
       "Imageflow.NativeTool.win-x86_64": {
         "type": "Direct",
-        "requested": "[2.3.1-rc01, )",
+        "requested": "[2.3.1-rc01, 4.0.0)",
         "resolved": "2.3.1-rc01",
         "contentHash": "mYJQf4WBFXY5Cz3B1yMH29JQAhDpQbKH8kmmz3mnafkvTBkxeMNEaceb1rA0HBQyAXiVctBbJ7mXLWe7dBmvWw=="
       },
@@ -683,7 +683,7 @@
       "imageflow.allplatforms": {
         "type": "Project",
         "dependencies": {
-          "Imageflow.NativeRuntime.All": "[2.3.1-rc01, )",
+          "Imageflow.NativeRuntime.All": "[2.3.1-rc01, 4.0.0)",
           "Imageflow.Net": "[0.1.0--notset, )"
         }
       },


### PR DESCRIPTION
## Summary

Adds the .NET bindings for imageflow's new three-layer codec killbits system. Pairs with [imazen/imageflow#720](https://github.com/imazen/imageflow/pull/720), which introduces `v1/context/set_policy` and `v1/context/get_net_support` on the existing `imageflow_context_send_json` ABI (no new C exports).

**Do not merge until imageflow#720 lands and a native runtime including it is published to NuGet.** This PR is draft until then.

## API additions

- `ImageFormat`, `NamedEncoderName`, `NamedDecoderName` enums with snake_case wire-form helpers (`ToSnakeCase` / `TryParse`). Mirrors the native `#[non_exhaustive]` enums; unknown strings from the grid are preserved as-is.
- `FormatKillbits`, `CodecKillbits`, `FormatPermissions` — mutual-exclusion validation (`Validate`) + job-level narrowing check (`ValidateJobLevel`) mirroring the native deserializer.
- `SecurityOptions` extended with scalar limits (`MaxInputFileBytes`, `MaxJsonBytes`, `MaxTotalFilePixels`) and both killbits blocks. `ImageJob` calls `ValidateJobLevel` before the payload crosses the ABI so allow-lists fail fast with a clear message.
- `JobContext.SetPolicy(SecurityOptions, bool requireUnlocked = false)` wrapping `v1/context/set_policy`. Returns `SetPolicyResponse` with the post-policy net-support grid.
- `JobContext.GetNetSupport()` wrapping `v1/context/get_net_support`. Returns `NetSupportResponse` cached per-context (see below).
- `KillbitsDeniedException : ImageflowException` — parses the structured `codec_not_available` / `decode_not_available` / `encode_not_available` JSON envelope from `FlowError.message` and exposes `DenialKind`, `Codec`, `Format`, `Reasons`, and the full `NetSupport` grid at rejection time. Falls back to the raw text when the envelope shape changes.
- `ImageflowCapabilities` — process-wide static cache. Live today: `GetMimeType`, `GetExtensions`, `DetectFormat(ReadOnlySpan<byte>)` (magic-byte sniff covering JPEG, PNG, GIF, BMP, TIFF, WebP, JXL (naked + ISOBMFF), AVIF/HEIC (ftyp brand), PNM). Stubbed (returns null) until a native static-info endpoint lands: `GetEncoderCapabilities`, `GetRiapiKeys`.

### Example

```csharp
using var ctx = new JobContext();

var policy = new SecurityOptions
{
    MaxDecodeSize = new FrameSizeLimit(12000, 12000, 100f),
    Formats = new FormatKillbits
    {
        DenyEncode = new[] { ImageFormat.Avif, ImageFormat.Jxl },
    },
    Codecs = new CodecKillbits
    {
        DenyEncoders = new[] { NamedEncoderName.MozjpegEncoder },
    },
};
var response = ctx.SetPolicy(policy);
Console.WriteLine($"locked={response.Locked}, jpeg-encode={response.NetSupport.Formats["jpeg"].Encode}");

// Later: same grid, served from cache.
var grid = ctx.GetNetSupport();

try
{
    await job.Decode(src).EncodeToBytes(new WebPLosslessEncoder())
        .Finish().InProcessAndDisposeAsync();
}
catch (KillbitsDeniedException ex) when (ex.DenialKind == KillbitsDenialKind.EncodeNotAvailable)
{
    // ex.NetSupport is the grid at rejection time; use it to pick a fallback.
}
```

## Caching architecture

- **Per-context `NetSupportResponse` cache** — stored on `JobContext` behind a `Volatile.Read` / double-checked `lock (this)`. `GetNetSupport` is a plain field read after the first call; `SetPolicy` invalidates before issuing the native call and re-primes with the returned grid. A `NetSupportNativeCallCount` counter is exposed internally for tests to assert cache hits.
- **Process-wide static tables on `ImageflowCapabilities`** — MIME types and extensions are a `Lazy<Dictionary<...>>` populated from hard-coded tables (the data is a property of the native build; no endpoint needed). `DetectFormat` uses a stateless byte-sniff switch. `GetEncoderCapabilities` is backed by a `ConcurrentDictionary` keyed on the codec so the backing store can repoint at a native call without changing the signature. `GetRiapiKeys` is a single `Lazy<IReadOnlyList<string>?>`.
- **Thread safety** — every cache is either immutable-after-init (`Lazy<T>` default publication) or built from lock-free primitives (`ConcurrentDictionary`, `Volatile.Read`/`Volatile.Write`). The integration test `GetNetSupport_ThreadSafe_OnlyOneNativeCall` spawns 16 threads; all see the same instance and only one native call is made.

## Breaking changes

None expected. `SecurityOptions` gains properties and methods; no existing members changed. No rename, no signature change.

## Native runtime

The killbits endpoints are not present in `Imageflow.NativeTool 2.3.1-rc01` currently resolved by the test csproj. Once imageflow#720 merges and a prerelease NuGet drops, we can start exercising the `Category=KillbitsIntegration` suite under `IMAGEFLOW_HAS_KILLBITS=1`.

### Version range strategy

`Imageflow.NativeRuntime.*` and `Imageflow.NativeTool.*` now resolve from **`[2.3.1-rc01, 4.0.0)`** (see commit `e0a025c`):

- **Floor `2.3.1-rc01`** — NuGet's lowest-applicable rule keeps resolution at `2.3.1-rc01` today (identical to the previous implicit `[2.3.1-rc01, )`). The prerelease lower bound is required to opt into prerelease resolution; no stable 2.x exists, and a stable floor would fail to restore.
- **Upper cap `< 4.0.0`** — permits automatic adoption of any v3.x native runtime (the first to ship the killbits endpoints) while blocking unintentional jumps across a future v4 major.
- Applies to `tests/Imageflow.Test/Imageflow.Test.csproj` (all 7 `Imageflow.NativeTool.<rid>` entries) and `src/Imageflow.AllPlatforms/Imageflow.AllPlatforms.csproj` (`Imageflow.NativeRuntime.All`).
- `tests/Imageflow.TestDotNetFull/*` stays pinned at `2.3.1-rc01`. `packages.config` embeds the exact version into the `.targets` import path; ranges are not supported in that format. This project is legacy `net462`/`net472` gated behind the `test_legacy` matrix on Windows.

**Follow-up when a v3 killbits-capable prerelease publishes:** bump `tests/Imageflow.Test`'s floor to `[3.0.0-alpha.0, 4.0.0)` to force v3 selection so `Category=KillbitsIntegration` runs against it. `Imageflow.AllPlatforms` can stay on `[2.3.1-rc01, 4.0.0)` so downstream consumers keep building against v2 by default until v3 is ready.

## Test plan

- [x] `dotnet test --framework net10.0 --filter "Category!=KillbitsIntegration"` — **150 passing** locally (146 pre-existing + 36 new unit tests)
- [x] `dotnet test --framework net8.0 --filter "Category!=KillbitsIntegration"` — **150 passing** locally
- [ ] `dotnet test --framework net9.0 ...` — deferred to CI (runtime not installed locally)
- [ ] `IMAGEFLOW_HAS_KILLBITS=1 dotnet test --filter "Category=KillbitsIntegration"` — will run once a killbits-capable native runtime is pinned; today it correctly errors with `InvalidMessageEndpoint` against 2.3.1-rc01, confirming the client reaches the native side.

Integration tests live behind a `KillbitsFactAttribute` that checks `IMAGEFLOW_HAS_KILLBITS=1`; the skip decision is owned by the caller (CI workflow / env var), not by runtime endpoint sniffing, per repo policy on graceful skips.

## Deferred

- `ImageflowCapabilities.GetEncoderCapabilities` and `GetRiapiKeys` return `null` today. Accessors are shaped and cached; swap the backing lazies once imageflow exposes a static-info endpoint.
- The `InvokeAndParse(method)` path on `JobContext` uses the existing null-body shape (`{}`). `v1/context/get_net_support` accepts this; no rework needed even if it later takes parameters (new overload would slot in).
